### PR TITLE
Improve naming (expects/exposes rather than gets/sets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,9 @@
 ## UNRELEASED
 
 * N/A
+
+## 0.1.0-alpha.1.1
+* revert `gets` / `sets` back to `expects` / `exposes`
+
+## 0.1.0-alpha.1
+* Initial implementation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    axn (0.1.0.pre.alpha.1)
+    axn (0.1.0.pre.alpha.1.1)
       activemodel (> 7.0)
       activesupport (> 7.0)
       interactor (= 3.1.2)

--- a/lib/action/context_facade.rb
+++ b/lib/action/context_facade.rb
@@ -108,7 +108,7 @@ module Action
 
     private
 
-    def exposure_method_name = :gets
+    def exposure_method_name = :expects
   end
 
   # Outbound / External ContextFacade
@@ -138,7 +138,7 @@ module Action
 
     private
 
-    def exposure_method_name = :sets
+    def exposure_method_name = :exposes
   end
 
   class Inspector

--- a/lib/action/contract.rb
+++ b/lib/action/contract.rb
@@ -34,8 +34,8 @@ module Action
     FieldConfig = Data.define(:field, :validations, :default, :preprocess, :sensitive)
 
     module ClassMethods
-      def gets(*fields, allow_blank: false, default: nil, preprocess: nil, sensitive: false,
-               **validations)
+      def expects(*fields, allow_blank: false, default: nil, preprocess: nil, sensitive: false,
+                  **validations)
         _parse_field_configs(*fields, allow_blank:, default:, preprocess:, sensitive:, **validations).tap do |configs|
           duplicated = internal_field_configs.map(&:field) & configs.map(&:field)
           raise Action::DuplicateFieldError, "Duplicate field(s) declared: #{duplicated.join(", ")}" if duplicated.any?
@@ -45,7 +45,7 @@ module Action
         end
       end
 
-      def sets(*fields, allow_blank: false, default: nil, sensitive: false, **validations)
+      def exposes(*fields, allow_blank: false, default: nil, sensitive: false, **validations)
         _parse_field_configs(*fields, allow_blank:, default:, preprocess: nil, sensitive:, **validations).tap do |configs|
           duplicated = external_field_configs.map(&:field) & configs.map(&:field)
           raise Action::DuplicateFieldError, "Duplicate field(s) declared: #{duplicated.join(", ")}" if duplicated.any?
@@ -84,16 +84,16 @@ module Action
       def internal_context = @internal_context ||= _build_context_facade(:inbound)
       def external_context = @external_context ||= _build_context_facade(:outbound)
 
-      # NOTE: ideally no direct access from client code, but we need to set this for internal Interactor methods
+      # NOTE: ideally no direct access from client code, but we need to expose this for internal Interactor methods
       # (and passing through control methods to underlying context) in order to avoid rewriting internal methods.
       def context = external_context
 
       # Accepts either two positional arguments (key, value) or a hash of key/value pairs
-      def set(*args, **kwargs)
+      def expose(*args, **kwargs)
         if args.any?
           if args.size != 2
             raise ArgumentError,
-                  "set must be called with exactly two positional arguments (or a hash of key/value pairs)"
+                  "expose must be called with exactly two positional arguments (or a hash of key/value pairs)"
           end
 
           kwargs.merge!(args.first => args.last)

--- a/lib/action/exceptions.rb
+++ b/lib/action/exceptions.rb
@@ -42,7 +42,7 @@ module Action
         super()
       end
 
-      def message = "Attempted to set unknown key '#{@key}': be sure to declare it with `sets :#{@key}`"
+      def message = "Attempted to expose unknown key '#{@key}': be sure to declare it with `exposes :#{@key}`"
     end
   end
 

--- a/lib/axn/version.rb
+++ b/lib/axn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Axn
-  VERSION = "0.1.0-alpha.1"
+  VERSION = "0.1.0-alpha.1.1"
 end

--- a/spec/action/hoist_errors_spec.rb
+++ b/spec/action/hoist_errors_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Action do
 
     let(:action) do
       build_action do
-        gets :subaction
+        expects :subaction
         def call
           hoist_errors(prefix: "FROM HOIST:") { subaction.call }
         end
@@ -56,7 +56,7 @@ RSpec.describe Action do
     context "when the hoist_errors not given a block" do
       let(:action) do
         build_action do
-          gets :subaction
+          expects :subaction
           def call
             hoist_errors(prefix: "FROM HOIST:")
           end

--- a/spec/action/inspect_spec.rb
+++ b/spec/action/inspect_spec.rb
@@ -3,17 +3,17 @@
 RSpec.describe Action do
   let(:action) do
     build_action do
-      gets :foo, type: Numeric, numericality: { greater_than: 10 }
-      gets :ssn, sensitive: true
+      expects :foo, type: Numeric, numericality: { greater_than: 10 }
+      expects :ssn, sensitive: true
 
-      sets :bar
-      sets :phone, sensitive: true
-      sets :the_internal_context, sensitive: true
+      exposes :bar
+      exposes :phone, sensitive: true
+      exposes :the_internal_context, sensitive: true
 
       def call
-        set :bar, foo * 10
-        set :phone, "123-456-7890"
-        set :the_internal_context, internal_context
+        expose :bar, foo * 10
+        expose :phone, "123-456-7890"
+        expose :the_internal_context, internal_context
         fail! "intentional error" if foo == 13
       end
     end

--- a/spec/action/logging_spec.rb
+++ b/spec/action/logging_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Action do
   describe "Logging" do
     let(:action) do
       build_action do
-        gets :level, default: :info
+        expects :level, default: :info
         def call
           log("Hello, World!", level:)
         end

--- a/spec/action/messages_spec.rb
+++ b/spec/action/messages_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Action do
       context "when dynamic" do
         let(:action) do
           build_action do
-            gets :foo, default: "bar"
+            expects :foo, default: "bar"
             messages(success: -> { "Great news: #{@var} from #{foo}" })
 
             def call
@@ -39,11 +39,11 @@ RSpec.describe Action do
       context "when dynamic with exposed vars" do
         let(:action) do
           build_action do
-            sets :foo, default: "bar"
+            exposes :foo, default: "bar"
             messages(success: -> { "Great news: #{@var} from #{foo}" })
 
             def call
-              set foo: "baz"
+              expose foo: "baz"
               @var = 123
             end
           end
@@ -58,7 +58,7 @@ RSpec.describe Action do
       context "when dynamic raises error" do
         let(:action) do
           build_action do
-            gets :foo, default: "bar"
+            expects :foo, default: "bar"
             messages(success: -> { "Great news: #{@var} from #{foo} and #{some_undefined_var}" })
 
             def call
@@ -93,7 +93,7 @@ RSpec.describe Action do
       context "when static" do
         let(:action) do
           build_action do
-            gets :missing_param
+            expects :missing_param
             messages(error: "Bad news!")
           end
         end
@@ -109,7 +109,7 @@ RSpec.describe Action do
       context "when dynamic" do
         let(:action) do
           build_action do
-            gets :missing_param
+            expects :missing_param
             messages(error: -> { "Bad news: #{@var}" })
 
             def call
@@ -132,7 +132,7 @@ RSpec.describe Action do
       context "when dynamic wants exception" do
         let(:action) do
           build_action do
-            gets :missing_param
+            expects :missing_param
             messages(error: ->(e) { "Bad news: #{e.class.name}" })
           end
         end
@@ -151,7 +151,7 @@ RSpec.describe Action do
       context "when dynamic returns blank" do
         let(:action) do
           build_action do
-            gets :missing_param
+            expects :missing_param
             messages(error: -> { "" })
           end
         end
@@ -172,7 +172,7 @@ RSpec.describe Action do
       context "when static" do
         let(:action) do
           build_action do
-            gets :param
+            expects :param
             messages(error: "Bad news!")
             rescues ArgumentError, ->(e) { "Argument error: #{e.message}" }
             rescues "Action::InboundValidationError" => "Inbound validation error!"

--- a/spec/action/on_exception_spec.rb
+++ b/spec/action/on_exception_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Action do
 
     let(:action) do
       build_action do
-        gets :name
-        gets :ssn, sensitive: true
-        sets :outbound
+        expects :name
+        expects :ssn, sensitive: true
+        exposes :outbound
 
         def call
           raise "Some internal issue!"
@@ -37,7 +37,7 @@ RSpec.describe Action do
 
     let(:action) do
       build_action do
-        gets :should_fail, allow_blank: true, default: false
+        expects :should_fail, allow_blank: true, default: false
 
         def call
           try do

--- a/spec/action/swallow_exceptions_messages_spec.rb
+++ b/spec/action/swallow_exceptions_messages_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Action do
 
     let(:action) do
       build_action do
-        gets :klass, allow_blank: true
+        expects :klass, allow_blank: true
 
         messages(
           success: "great news",

--- a/spec/action/validations_spec.rb
+++ b/spec/action/validations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Action do
   describe "inbound validation" do
     let(:action) do
       build_action do
-        gets :foo, type: Numeric, numericality: { greater_than: 10 }
+        expects :foo, type: Numeric, numericality: { greater_than: 10 }
       end
     end
 
@@ -30,11 +30,11 @@ RSpec.describe Action do
   describe "outbound validation" do
     let(:action) do
       build_action do
-        sets :bar, type: Numeric, numericality: { greater_than: 10 }
-        sets :qux, type: Numeric
+        exposes :bar, type: Numeric, numericality: { greater_than: 10 }
+        exposes :qux, type: Numeric
 
         def call
-          set :qux, 99
+          expose :qux, 99
         end
       end
     end
@@ -44,11 +44,11 @@ RSpec.describe Action do
 
       it { is_expected.to be_success }
 
-      it "sets existing context" do
+      it "exposes existing context" do
         expect(subject.bar).to eq(11)
       end
 
-      it "sets new values" do
+      it "exposes new values" do
         expect(subject.qux).to eq(99)
       end
 
@@ -74,10 +74,10 @@ RSpec.describe Action do
 
       let(:action) do
         build_action do
-          sets :bar, type: Numeric, numericality: { greater_than: 10 }
+          exposes :bar, type: Numeric, numericality: { greater_than: 10 }
 
           def call
-            set :qux, 99
+            expose :qux, 99
           end
         end
       end
@@ -93,8 +93,8 @@ RSpec.describe Action do
   describe "complex validation" do
     let(:action) do
       build_action do
-        gets :foo, type: String
-        sets :bar, type: String
+        expects :foo, type: String
+        exposes :bar, type: String
       end
     end
 

--- a/spec/fixtures/date_organizer.rb
+++ b/spec/fixtures/date_organizer.rb
@@ -5,11 +5,11 @@
 class DateParser
   include Action
 
-  gets :date, type: String
-  sets :date, type: Date
+  expects :date, type: String
+  exposes :date, type: Date
 
   def call
-    set date: Date.parse(date)
+    expose date: Date.parse(date)
   end
 
   messages error: "Parsing the date went poorly"
@@ -18,11 +18,11 @@ end
 class DateEvaluator
   include Action
 
-  gets :date, type: Date
-  sets :year, type: Integer
+  expects :date, type: Date
+  exposes :year, type: Integer
 
   def call
-    set :year, date.year
+    expose :year, date.year
   end
 end
 
@@ -35,8 +35,8 @@ end
 class ServiceActionOrganizer
   include Action::Organizer
 
-  gets :date, type: String
-  sets :year, type: Integer
+  expects :date, type: String
+  exposes :year, type: Integer
 
   organize DateParser, DateEvaluator
 end

--- a/spec/fixtures/enqueueable.rb
+++ b/spec/fixtures/enqueueable.rb
@@ -6,7 +6,7 @@ class TestEnqueueableInteractor
   include Action
   queue_options retry: 10, retry_queue: "low"
 
-  gets :name, :address
+  expects :name, :address
 
   def call
     puts "Name: #{name}"
@@ -18,7 +18,7 @@ class AnotherEnqueueableInteractor
   include Action
   queue_options retry: 10, retry_queue: "low"
 
-  gets :foo
+  expects :foo
 
   def call
     puts "Another Interactor: #{foo}"

--- a/spec/oneoff_confirmations/composition_spec.rb
+++ b/spec/oneoff_confirmations/composition_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "One-off confirmation" do
         def self.included(base)
           base.class_eval do
             include Action
-            gets :wrapper_thing
+            expects :wrapper_thing
             before do
               log "before from wrapper"
             end
@@ -22,15 +22,15 @@ RSpec.describe "One-off confirmation" do
 
     let(:action) do
       build_action do
-        gets :name, type: String
-        sets :greeting, type: String
+        expects :name, type: String
+        exposes :greeting, type: String
 
         before do
           log "before from action"
         end
 
         def call
-          set greeting: "hi, #{name.upcase}"
+          expose greeting: "hi, #{name.upcase}"
         end
       end
     end
@@ -49,15 +49,15 @@ RSpec.describe "One-off confirmation" do
 
       let(:action) do
         build_wrapper_action do
-          gets :name, type: String
-          sets :greeting, type: String
+          expects :name, type: String
+          exposes :greeting, type: String
 
           before do
             log "before from action"
           end
 
           def call
-            set greeting: "hi, #{name.upcase}"
+            expose greeting: "hi, #{name.upcase}"
           end
         end
       end

--- a/spec/oneoff_confirmations/inheritance_and_contracts_spec.rb
+++ b/spec/oneoff_confirmations/inheritance_and_contracts_spec.rb
@@ -7,24 +7,24 @@
 RSpec.describe "One-off confirmation: inheritance and contracts" do
   let(:base) do
     build_action do
-      gets :foo, type: Numeric, numericality: { greater_than: 10 }
-      sets :bar, type: Numeric
+      expects :foo, type: Numeric, numericality: { greater_than: 10 }
+      exposes :bar, type: Numeric
 
       def call
-        set bar: foo * 10
+        expose bar: foo * 10
       end
     end
   end
 
   let(:version_a) do
     Class.new(base) do
-      gets :baz, default: 123
+      expects :baz, default: 123
     end
   end
 
   let(:version_b) do
     Class.new(base) do
-      gets :baz, default: 100
+      expects :baz, default: 100
     end
   end
 

--- a/spec/oneoff_confirmations/inheritance_spec.rb
+++ b/spec/oneoff_confirmations/inheritance_spec.rb
@@ -8,10 +8,10 @@ module CustomActionWithFoo
   def self.included(base)
     base.class_eval do
       include Action
-      gets :foo, type: Numeric, numericality: { greater_than: 10 }
-      sets :bar, type: Numeric
+      expects :foo, type: Numeric, numericality: { greater_than: 10 }
+      exposes :bar, type: Numeric
       def call
-        set bar: foo * 10
+        expose bar: foo * 10
       end
     end
   end
@@ -19,10 +19,10 @@ end
 
 class ComposedClass
   include CustomActionWithFoo
-  gets :baz, default: 123
+  expects :baz, default: 123
 
   def call
-    set bar: baz
+    expose bar: baz
   end
 end
 

--- a/spec/oneoff_confirmations/interface_interdependency_spec.rb
+++ b/spec/oneoff_confirmations/interface_interdependency_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "One-off confirmation" do
     describe "default accepts proc" do
       let(:action) do
         build_action do
-          gets :channel, default: -> { valid_channels.first }
+          expects :channel, default: -> { valid_channels.first }
 
           def call
             log "Got channel: #{channel}"
@@ -30,8 +30,8 @@ RSpec.describe "One-off confirmation" do
       # describe "validations can reference instance methods" do
       #   let(:action) do
       #     build_action do
-      #       gets :channel, inclusion: { in: :valid_channels_for_number }
-      #       gets :number
+      #       expects :channel, inclusion: { in: :valid_channels_for_number }
+      #       expects :number
 
       #       def call
       #         log "Got channel: #{channel}"
@@ -62,7 +62,7 @@ RSpec.describe "One-off confirmation" do
             # NOTE: only works if method already defined!
             def self.valid_channels_for_number = ["overridden_valid_channels"]
 
-            gets :channel, inclusion: { in: valid_channels_for_number }
+            expects :channel, inclusion: { in: valid_channels_for_number }
 
             def call
               log "Got channel: #{channel}"

--- a/spec/single_module_focus/contract_spec.rb
+++ b/spec/single_module_focus/contract_spec.rb
@@ -5,8 +5,8 @@ require "action/contract"
 RSpec.describe Action::Contract do
   let(:interactor) do
     build_interactor(described_class) do
-      gets :foo, type: Numeric, numericality: { greater_than: 10 }
-      sets :bar
+      expects :foo, type: Numeric, numericality: { greater_than: 10 }
+      exposes :bar
 
       def call
         foo * 10
@@ -50,11 +50,11 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        gets :foo, type: Numeric, numericality: { greater_than: 10 }
-        sets :the_internal_context
+        expects :foo, type: Numeric, numericality: { greater_than: 10 }
+        exposes :the_internal_context
 
         def call
-          set :the_internal_context, internal_context
+          expose :the_internal_context, internal_context
         end
       end
     end
@@ -91,8 +91,8 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        gets :foo, type: Numeric, numericality: { greater_than: 10 }, allow_blank: true
-        sets :bar, allow_blank: true
+        expects :foo, type: Numeric, numericality: { greater_than: 10 }, allow_blank: true
+        exposes :bar, allow_blank: true
       end
     end
 
@@ -104,8 +104,8 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        gets :foo, type: Numeric, default: 99
-        sets :foo
+        expects :foo, type: Numeric, default: 99
+        exposes :foo
       end
     end
 
@@ -120,7 +120,7 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        sets :foo, default: 99
+        exposes :foo, default: 99
       end
     end
 
@@ -130,21 +130,21 @@ RSpec.describe Action::Contract do
     end
   end
 
-  describe "#set" do
+  describe "#expose" do
     subject { interactor.call }
 
     let(:interactor) do
       build_interactor(described_class) do
-        sets :qux
+        exposes :qux
 
         def call
-          set :qux, 11 # Just confirming can call twice
-          set :qux, 99
+          expose :qux, 11 # Just confirming can call twice
+          expose :qux, 99
         end
       end
     end
 
-    it "can set" do
+    it "can expose" do
       is_expected.to be_success
       expect(subject.qux).to eq 99
     end
@@ -155,7 +155,7 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        gets :foo, type: [String, Numeric]
+        expects :foo, type: [String, Numeric]
       end
     end
 
@@ -184,7 +184,7 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        gets :foo, boolean: true
+        expects :foo, boolean: true
       end
     end
 
@@ -209,7 +209,7 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        gets :foo, :bar, type: { with: Numeric, message: "should numberz" }
+        expects :foo, :bar, type: { with: Numeric, message: "should numberz" }
       end
     end
 
@@ -228,11 +228,11 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        gets :foo, boolean: true
-        sets :bar, allow_blank: true
+        expects :foo, boolean: true
+        exposes :bar, allow_blank: true
 
         def call
-          set :bar, 99 if foo
+          expose :bar, 99 if foo
         end
       end
     end
@@ -253,11 +253,11 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        gets :date_as_date, type: Date, preprocess: ->(raw) { Date.parse(raw) }
-        sets :date_as_date
+        expects :date_as_date, type: Date, preprocess: ->(raw) { Date.parse(raw) }
+        exposes :date_as_date
 
         def call
-          set date_as_date:
+          expose date_as_date:
         end
       end
     end
@@ -287,7 +287,7 @@ RSpec.describe Action::Contract do
 
     let(:interactor) do
       build_interactor(described_class) do
-        gets :foo, validate: ->(value) { "must be pretty big" unless value > 10 }
+        expects :foo, validate: ->(value) { "must be pretty big" unless value > 10 }
       end
     end
 
@@ -303,7 +303,7 @@ RSpec.describe Action::Contract do
     context "when validator raises" do
       let(:interactor) do
         build_interactor(described_class) do
-          gets :foo, validate: ->(_value) { raise "oops" }
+          expects :foo, validate: ->(_value) { raise "oops" }
         end
       end
 
@@ -315,13 +315,13 @@ RSpec.describe Action::Contract do
     end
   end
 
-  describe "#gets" do
-    context "with multiple fields per gets line" do
+  describe "#expects" do
+    context "with multiple fields per expects line" do
       subject { interactor.call(foo:, bar:) }
 
       let(:interactor) do
         build_interactor(described_class) do
-          gets :foo, :bar, type: Numeric
+          expects :foo, :bar, type: Numeric
         end
       end
 
@@ -341,8 +341,8 @@ RSpec.describe Action::Contract do
     context "with multiple expectations on the same field" do
       let(:interactor) do
         build_interactor(described_class) do
-          gets :foo, type: String
-          gets :foo, numericality: { greater_than: 10 }
+          expects :foo, type: String
+          expects :foo, numericality: { greater_than: 10 }
         end
       end
 
@@ -352,18 +352,18 @@ RSpec.describe Action::Contract do
     end
   end
 
-  describe "#sets" do
-    context "with multiple fields per gets line" do
+  describe "#exposes" do
+    context "with multiple fields per expects line" do
       subject { interactor.call(baz:) }
 
       let(:baz) { 100 }
       let(:interactor) do
         build_interactor(described_class) do
-          gets :baz
-          sets :foo, :bar, type: Numeric
+          expects :baz
+          exposes :foo, :bar, type: Numeric
 
           def call
-            set foo: baz, bar: baz
+            expose foo: baz, bar: baz
           end
         end
       end
@@ -381,8 +381,8 @@ RSpec.describe Action::Contract do
     context "with multiple expectations on the same field" do
       let(:interactor) do
         build_interactor(described_class) do
-          sets :foo, type: String
-          sets :foo, numericality: { greater_than: 10 }
+          exposes :foo, type: String
+          exposes :foo, numericality: { greater_than: 10 }
         end
       end
 
@@ -396,7 +396,7 @@ RSpec.describe Action::Contract do
 
       let(:interactor) do
         build_interactor(described_class) do
-          sets :foo, default: "bar"
+          exposes :foo, default: "bar"
 
           def call
             puts "Foo is: #{foo}"


### PR DESCRIPTION
For the initial alpha release we were experimenting with `gets`/`sets` as the interface declaration methods.  After seeing what that looks like in practice, and consulting with the Staff Engineers, we decided the `expects` / `exposes` naming is clearer (while slightly less terse, it's clearer that these are declaration methods -- gets / sets feel more like getters/setters).