### PR TITLE
rescues + error_from (NOTE: interface change!)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   SuggestExtensions: false
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * N/A
 
 * Renamed `.rescues` to `.error_from`
+* Implemented new `.rescues` (like `.error_from`, but also avoids triggering on_exception handler)
 
 ## 0.1.0-alpha.1.1
 * revert `gets` / `sets` back to `expects` / `exposes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## UNRELEASED
-
 * N/A
+
+* Renamed `.rescues` to `.error_from`
 
 ## 0.1.0-alpha.1.1
 * revert `gets` / `sets` back to `expects` / `exposes`

--- a/axn.gemspec
+++ b/axn.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/teamshares/axn"
   spec.license = "MIT"
 
-  # NOTE: uses endless methods from 3, literal value omission from 3.1
-  spec.required_ruby_version = ">= 3.1.0"
+  # NOTE: uses endless methods from 3, literal value omission from 3.1, Data.define from 3.2
+  spec.required_ruby_version = ">= 3.2.0"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
   # spec.metadata["rubygems_mfa_required"] = "true"

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -56,3 +56,20 @@ Accepts `error` and/or `success` keys.  Values can be a string (returned directl
 ```ruby
 messages success: "All good!", error: ->(e) { "Bad news: #{e.message}" }
 ```
+
+## `error_for` and `rescues`
+
+While `.messages` sets the _default_ error/success messages and is more commonly used, there are times when you want specific error messages for specific failure cases.
+
+`error_for` and `rescues` both register a matcher (exception class, exception class name (string), or callable) and a message to use if the matcher succeeds.  They act exactly the same, except if a matcher registered with `rescues` succeeds, the exception _will not_ trigger the configured global error handler.
+
+```ruby
+messages error: "bad"
+
+# Note this will NOT trigger Action.config.on_exception
+rescues ActiveRecord::InvalidRecord => "Invalid params provided"
+
+# These WILL trigger error handler (second demonstrates callable matcher AND message)
+error_for ArgumentError, ->(e) { "Argument error: #{e.message}"
+error_for -> { name == "bad" }, -> { "was given bad name: #{name}" }
+```

--- a/lib/action/core/context_facade.rb
+++ b/lib/action/core/context_facade.rb
@@ -61,7 +61,7 @@ module Action
     end
 
     def message_from_rescues
-      Array(action._error_rescues).each do |(matcher, value)|
+      Array(action._error_from).each do |(matcher, value)|
         matches = if matcher.respond_to?(:call)
                     if matcher.arity == 1
                       !!action.instance_exec(exception, &matcher)

--- a/lib/action/core/context_facade.rb
+++ b/lib/action/core/context_facade.rb
@@ -51,21 +51,15 @@ module Action
     def determine_error_message(only_default: false)
       return @context.error_from_user if @context.error_from_user.present?
 
+      exception = @context.exception || (only_default ? Action::Failure.new(@context) : nil)
+      msg = action._error_msg
+
       unless only_default
-        msg = message_from_custom_settings
-        return msg if msg.present?
+        interceptor = action.class._error_interceptor_for(exception:, action:)
+        msg = interceptor.message if interceptor
       end
 
-      the_exception = @context.exception || (only_default ? Action::Failure.new(@context) : nil)
-      stringified(action._error_msg, exception: the_exception).presence || "Something went wrong"
-    end
-
-    def message_from_custom_settings
-      Array(action._custom_error_layers).each do |layer|
-        return stringified(layer.message, exception:) if layer.matches?(exception:, action:)
-      end
-
-      nil
+      stringified(msg, exception:).presence || "Something went wrong"
     end
 
     # Allow for callable OR string messages

--- a/lib/action/core/swallow_exceptions.rb
+++ b/lib/action/core/swallow_exceptions.rb
@@ -5,7 +5,7 @@ module Action
     def self.included(base)
       base.class_eval do
         class_attribute :_success_msg, :_error_msg
-        class_attribute :_error_rescues, default: []
+        class_attribute :_error_from, default: []
 
         include InstanceMethods
         extend ClassMethods
@@ -69,10 +69,10 @@ module Action
         true
       end
 
-      def rescues(matcher = nil, message = nil, **match_and_messages)
-        raise ArgumentError, "rescues must be called with a key, value pair or else keyword args" if [matcher, message].compact.size == 1
+      def error_from(matcher = nil, message = nil, **match_and_messages)
+        raise ArgumentError, "error_from must be called with a key, value pair or else keyword args" if [matcher, message].compact.size == 1
 
-        { matcher => message }.compact.merge(match_and_messages).each { |mam| self._error_rescues += [mam] }
+        { matcher => message }.compact.merge(match_and_messages).each { |mam| self._error_from += [mam] }
       end
 
       def default_error = new.internal_context.default_error

--- a/lib/axn.rb
+++ b/lib/axn.rb
@@ -19,10 +19,10 @@ require_relative "axn/factory"
 
 require_relative "action/attachable"
 
-def Axn(callable, **kwargs) # rubocop:disable Naming/MethodName
+def Axn(callable, **) # rubocop:disable Naming/MethodName
   return callable if callable.is_a?(Class) && callable < Action
 
-  Axn::Factory.build(**kwargs, &callable)
+  Axn::Factory.build(**, &callable)
 end
 
 module Action

--- a/spec/action/core/messages_spec.rb
+++ b/spec/action/core/messages_spec.rb
@@ -188,8 +188,15 @@ RSpec.describe Action do
         end
       end
 
+      before do
+        expect_any_instance_of(action).to receive(:trigger_on_exception).and_call_original
+      end
+
       it { expect(result).not_to be_ok }
-      it { expect(result.error).to eq("Inbound validation error!") }
+
+      it "matches by string exception class name" do
+        expect(result.error).to eq("Inbound validation error!")
+      end
 
       it "matches specific exceptions" do
         expect(action.call(param: 1).error).to eq("Argument error: bad arg")

--- a/spec/action/core/messages_spec.rb
+++ b/spec/action/core/messages_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Action do
 
             raise "something else"
           end
-        end.tap do |a|
+        end.tap do |a| # rubocop:disable Style/MultilineBlockChain
           a.public_send(method_under_test, ArgumentError, ->(e) { "Argument error: #{e.message}" })
           a.public_send(method_under_test, "Action::InboundValidationError" => "Inbound validation error!")
           a.public_send(method_under_test, -> { param == 2 }, -> { "whoa a #{param}" })


### PR DESCRIPTION
Axn needs a class-level interface for declaring custom exception -> message matchers.  First alpha implemented as `rescues`, but that's super misleading because it's not actually rescued (i.e. it still triggers the on_exception handler).

### Tasks
- [x] Rename existing `rescues` -> `error_from` (sets a custom error message, but doesn't prevent triggering on_exception handler)
- [x] Implement _new_ `rescues` — same as `error_from`, except _do_ prevent triggering handler