### PR TITLE
Better support for `Action::Result.ok` and `Action::Result.error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## UNRELEASED
-* N/A
+* Expands `Action::Result.ok` and `Action::Result.error` to better support mocking in specs
 
 ## 0.1.0-alpha.2.1
 * Expects/Exposes: Add `allow_nil` option

--- a/docs/recipes/testing.md
+++ b/docs/recipes/testing.md
@@ -4,7 +4,36 @@
 * TODO: document testing patterns
 :::
 
-Configuring rspec to treat files in spec/actions as service specs:
+## Mocking Axn calls
+
+Say you're writing unit specs for PrimaryAction that calls Subaction, and you want to mock out the Subaction call.
+
+To generate a successful Action::Result:
+
+* Base case: `Action::Result.ok`
+* [Optional] Custom message: `Action::Result.ok("It went awesome")`
+* [Optional] Custom exposures: `Action::Result.ok("It went awesome", some_var: 123)`
+
+To generate a failed Action::Result:
+
+* Base case: `Action::Result.error`
+* [Optional] Custom message: `Action::Result.error("It went poorly")`
+* [Optional] Custom exposures: `Action::Result.error("It went poorly", some_var: 123)`
+* [Optional] Custom exception: `Action::Result.error(some_var: 123) { raise FooBarException.new("bad thing") }`
+
+Either way, using those to mock an actual call would look something like this in your rspec:
+
+```ruby
+let(:subaction_response) { Action::Result.ok("custom message", foo: 1) }
+
+before do
+  expect(Subaction).to receive(:call).and_return(subaction_response)
+end
+```
+
+## RSpec configuration
+
+Configuring rspec to treat files in spec/actions as service specs (very optional):
 
 ```ruby
 RSpec.configure do |config|

--- a/lib/action/core/context_facade.rb
+++ b/lib/action/core/context_facade.rb
@@ -102,11 +102,12 @@ module Action
         end.call
       end
 
-      def error(msg = nil, **exposures)
+      def error(msg = nil, **exposures, &block)
         Axn::Factory.build(exposes: exposures.keys, messages: { error: msg }) do
           exposures.each do |key, value|
             expose(key, value)
           end
+          block.call if block_given?
           fail!
         end.call
       end

--- a/lib/action/core/context_facade.rb
+++ b/lib/action/core/context_facade.rb
@@ -94,11 +94,20 @@ module Action
   class Result < ContextFacade
     # For ease of mocking return results in tests
     class << self
-      def ok = Class.new { include(Action) }.call
+      def ok(msg = nil, **exposures)
+        Axn::Factory.build(exposes: exposures.keys, messages: { success: msg }) do
+          exposures.each do |key, value|
+            expose(key, value)
+          end
+        end.call
+      end
 
-      def error(msg = "Something went wrong")
-        Class.new { include(Action) }.tap do |klass|
-          klass.define_method(:call) { fail!(msg) }
+      def error(msg = nil, **exposures)
+        Axn::Factory.build(exposes: exposures.keys, messages: { error: msg }) do
+          exposures.each do |key, value|
+            expose(key, value)
+          end
+          fail!
         end.call
       end
     end

--- a/lib/axn/factory.rb
+++ b/lib/axn/factory.rb
@@ -71,7 +71,7 @@ module Axn
             axn.exposes(field, **opts)
           end
 
-          axn.messages(**messages) if messages.present?
+          axn.messages(**messages) if messages.present? && messages.values.any?(&:present?)
 
           # Hooks
           axn.before(before) if before.present?

--- a/spec/action/result_for_specs_spec.rb
+++ b/spec/action/result_for_specs_spec.rb
@@ -26,11 +26,26 @@ RSpec.describe "Action spec helpers" do
       it { expect(result.error).to eq("Something went wrong") }
     end
 
-    context "with custom message" do
+    context "with custom message and exposure" do
       subject(:result) { Action::Result.error("Custom error message", still_exposable: 456) }
 
       it { is_expected.not_to be_ok }
       it { expect(result.error).to eq("Custom error message") }
+      it { expect(result.exception).to be_nil }
+      it { expect(result.still_exposable).to eq(456) }
+    end
+
+    context "with exception" do
+      subject(:result) do
+        Action::Result.error("default msg", still_exposable: 456) do
+          raise StandardError, "Custom error message"
+        end
+      end
+
+      it { is_expected.not_to be_ok }
+      it { expect(result.error).to eq("default msg") }
+      it { expect(result.exception).to be_a(StandardError) }
+      it { expect(result.exception.message).to eq("Custom error message") }
       it { expect(result.still_exposable).to eq(456) }
     end
   end

--- a/spec/action/result_for_specs_spec.rb
+++ b/spec/action/result_for_specs_spec.rb
@@ -2,22 +2,36 @@
 
 RSpec.describe "Action spec helpers" do
   describe "Action::Result.ok" do
-    subject(:result) { Action::Result.ok }
+    context "bare" do
+      subject(:result) { Action::Result.ok }
 
-    it { is_expected.to be_ok }
-    it { expect(result.success).to eq("Action completed successfully") }
+      it { is_expected.to be_ok }
+      it { expect(result.success).to eq("Action completed successfully") }
+    end
+
+    context "with custom message and exposure" do
+      subject(:result) { Action::Result.ok("optional success message", custom_exposure: 123) }
+
+      it { is_expected.to be_ok }
+      it { expect(result.success).to eq("optional success message") }
+      it { expect(result.custom_exposure).to eq(123) }
+    end
   end
 
   describe "Action::Result.error" do
-    subject(:result) { Action::Result.error }
+    context "bare" do
+      subject(:result) { Action::Result.error }
 
-    it { is_expected.not_to be_ok }
-    it { expect(result.error).to eq("Something went wrong") }
+      it { is_expected.not_to be_ok }
+      it { expect(result.error).to eq("Something went wrong") }
+    end
 
     context "with custom message" do
-      subject(:result) { Action::Result.error("Custom error message") }
+      subject(:result) { Action::Result.error("Custom error message", still_exposable: 456) }
 
+      it { is_expected.not_to be_ok }
       it { expect(result.error).to eq("Custom error message") }
+      it { expect(result.still_exposable).to eq(456) }
     end
   end
 end


### PR DESCRIPTION
Needed to support mocking out return values from an Axn call in specs.

---

Say you're writing unit specs for PrimaryAction that calls Subaction, and you want to mock out the Subaction call.

To generate a successful Action::Result:

* Base case: `Action::Result.ok`
* [Optional] Custom message: `Action::Result.ok("It went awesome")`
* [Optional] Custom exposures: `Action::Result.ok("It went awesome", some_var: 123)`

To generate a failed Action::Result:

* Base case: `Action::Result.error`
* [Optional] Custom message: `Action::Result.error("It went poorly")`
* [Optional] Custom exposures: `Action::Result.error("It went poorly", some_var: 123)`
* [Optional] Custom exception: `Action::Result.error(some_var: 123) { raise FooBarException.new("bad thing") }`

Either way, using those to mock an actual call would look something like this in your rspec:

```ruby
let(:subaction_response) { Action::Result.ok("custom message", foo: 1) }

before do
  expect(Subaction).to receive(:call).and_return(subaction_response)
end
```

