### PR TITLE
Alpha 2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## UNRELEASED
+* `expects` / `exposes`: Add `type: :uuid` special case validation
 
 ## 0.1.0-alpha.2.2
 * Expands `Action::Result.ok` and `Action::Result.error` to better support mocking in specs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 * `expects` / `exposes`: Add `type: :uuid` special case validation
 * [BUGFIX] Allow `hoist_errors` to pass the result through on success (allow access to subactions' exposures)
+* [`Axn::Factory`] Support error_from + rescues
 
 ## 0.1.0-alpha.2.2
 * Expands `Action::Result.ok` and `Action::Result.error` to better support mocking in specs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [BUGFIX] Allow `hoist_errors` to pass the result through on success (allow access to subactions' exposures)
 * [`Axn::Factory`] Support error_from + rescues
 * `Action::Result.error` spec helper -- creation should NOT trigger global exception handler
+* [CHANGE] `expects` / `exposes`: The `default` key, if a callable, should be evaluated in the _instance_'s context
 
 ## 0.1.0-alpha.2.2
 * Expands `Action::Result.ok` and `Action::Result.error` to better support mocking in specs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## UNRELEASED
+* N/A
+
+## 0.1.0-alpha.2.3
 * `expects` / `exposes`: Add `type: :uuid` special case validation
 * [BUGFIX] Allow `hoist_errors` to pass the result through on success (allow access to subactions' exposures)
 * [`Axn::Factory`] Support error_from + rescues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 * `expects` / `exposes`: Add `type: :uuid` special case validation
+* [BUGFIX] Allow `hoist_errors` to pass the result through on success (allow access to subactions' exposures)
 
 ## 0.1.0-alpha.2.2
 * Expands `Action::Result.ok` and `Action::Result.error` to better support mocking in specs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * `expects` / `exposes`: Add `type: :uuid` special case validation
 * [BUGFIX] Allow `hoist_errors` to pass the result through on success (allow access to subactions' exposures)
 * [`Axn::Factory`] Support error_from + rescues
+* `Action::Result.error` spec helper -- creation should NOT trigger global exception handler
 
 ## 0.1.0-alpha.2.2
 * Expands `Action::Result.ok` and `Action::Result.error` to better support mocking in specs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    axn (0.1.0.pre.alpha.2.2)
+    axn (0.1.0.pre.alpha.2.3)
       activemodel (> 7.0)
       activesupport (> 7.0)
       interactor (= 3.1.2)

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -25,6 +25,7 @@ While we _support_ complex interface validations, in practice you usually just w
 In addition to the [standard ActiveModel validations](https://guides.rubyonrails.org/active_record_validations.html), we also support two additional custom validators:
 * `type: Foo` - fails unless the provided value `.is_a?(Foo)`
   * Edge case: use `type: :boolean` to handle a boolean field (since ruby doesn't have a Boolean class to pass in directly)
+  * Edge case: use `type: :uuid` to handle a confirming given string is a UUID (with or without `-` chars)
 * `validate: [callable]` - Support custom validations (fails if any string is returned OR if it raises an exception)
   * Example:
     ```ruby

--- a/lib/action/core/context_facade.rb
+++ b/lib/action/core/context_facade.rb
@@ -103,7 +103,7 @@ module Action
       end
 
       def error(msg = nil, **exposures, &block)
-        Axn::Factory.build(exposes: exposures.keys, messages: { error: msg }) do
+        Axn::Factory.build(exposes: exposures.keys, rescues: [-> { true }, msg]) do
           exposures.each do |key, value|
             expose(key, value)
           end

--- a/lib/action/core/contract.rb
+++ b/lib/action/core/contract.rb
@@ -163,11 +163,12 @@ module Action
           hash[config.field] = config.default
         end.compact
 
-        defaults_mapping.each do |field, default_value|
-          unless @context.public_send(field)
-            @context.public_send("#{field}=",
-                                 default_value.respond_to?(:call) ? default_value.call : default_value)
-          end
+        defaults_mapping.each do |field, default_value_getter|
+          next if @context.public_send(field).present?
+
+          default_value = default_value_getter.respond_to?(:call) ? instance_exec(&default_value_getter) : default_value_getter
+
+          @context.public_send("#{field}=", default_value)
         end
       end
 

--- a/lib/action/core/contract_validator.rb
+++ b/lib/action/core/contract_validator.rb
@@ -54,6 +54,8 @@ module Action
         record.errors.add attribute, (options[:message] || msg) unless types.any? do |type|
           if type == :boolean
             [true, false].include?(value)
+          elsif type == :uuid
+            value.is_a?(String) && value.match?(/\A[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}\z/i)
           else
             value.is_a?(type)
           end

--- a/lib/action/core/hoist_errors.rb
+++ b/lib/action/core/hoist_errors.rb
@@ -36,7 +36,9 @@ module Action
                 "#hoist_errors is expected to wrap an Action call, but it returned a #{result.class.name} instead"
         end
 
-        _handle_hoisted_errors(result, prefix:) unless result.ok?
+        return result if result.ok?
+
+        _handle_hoisted_errors(result, prefix:)
       end
 
       # Separate method to allow overriding in subclasses

--- a/lib/axn/factory.rb
+++ b/lib/axn/factory.rb
@@ -14,6 +14,10 @@ module Axn
         exposes: [],
         expects: [],
         messages: {},
+        error_from: {},
+        rescues: {},
+
+        # Hooks
         before: nil,
         after: nil,
         around: nil,
@@ -73,6 +77,9 @@ module Axn
 
           axn.messages(**messages) if messages.present? && messages.values.any?(&:present?)
 
+          axn.error_from(**_array_to_hash(error_from)) if error_from.present?
+          axn.rescues(**_array_to_hash(rescues)) if rescues.present?
+
           # Hooks
           axn.before(before) if before.present?
           axn.after(after) if after.present?
@@ -97,6 +104,12 @@ module Axn
       private
 
       def _hash_with_default_array = Hash.new { |h, k| h[k] = [] }
+
+      def _array_to_hash(given)
+        return given if given.is_a?(Hash)
+
+        [given].to_h
+      end
 
       def _hydrate_hash(given)
         return given if given.is_a?(Hash)

--- a/lib/axn/version.rb
+++ b/lib/axn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Axn
-  VERSION = "0.1.0-alpha.2.2"
+  VERSION = "0.1.0-alpha.2.3"
 end

--- a/spec/action/core/hoist_errors_spec.rb
+++ b/spec/action/core/hoist_errors_spec.rb
@@ -4,18 +4,26 @@ RSpec.describe Action do
   describe "#hoist_errors" do
     subject { action.call(subaction:) }
 
-    let(:subaction) { build_action }
+    let(:subaction) do
+      build_action do
+        exposes :num
+        def call = expose :num, 123
+      end
+    end
 
     let(:action) do
       build_action do
         expects :subaction
+        exposes :num_from_subaction
         def call
-          hoist_errors(prefix: "FROM HOIST:") { subaction.call }
+          result = hoist_errors(prefix: "FROM HOIST:") { subaction.call }
+          expose :num_from_subaction, result.num
         end
       end
     end
 
     it { is_expected.to be_ok }
+    it { expect(subject.num_from_subaction).to eq(123) }
 
     context "when the subaction fails" do
       let(:subaction) do

--- a/spec/action/core/single_module_focus/contract_spec.rb
+++ b/spec/action/core/single_module_focus/contract_spec.rb
@@ -410,5 +410,23 @@ RSpec.describe Action::Contract do
         expect(subject).to be_ok
       end
     end
+
+    context "with default that is a callable" do
+      subject { interactor.call }
+
+      let(:interactor) do
+        build_interactor(described_class) do
+          exposes :foo, default: -> { "bar #{helper_method}" }
+
+          private
+
+          def helper_method = 123
+        end
+      end
+
+      it "has access to local helper methods" do
+        expect(subject.foo).to eq "bar 123"
+      end
+    end
   end
 end

--- a/spec/action/core/validations_spec.rb
+++ b/spec/action/core/validations_spec.rb
@@ -167,4 +167,22 @@ RSpec.describe Action do
       end
     end
   end
+
+  describe "uuid" do
+    let(:action) do
+      build_action do
+        expects :foo, type: :uuid
+      end
+    end
+
+    it "validates" do
+      expect(action.call(foo: "123e4567-e89b-12d3-a456-426614174000")).to be_ok
+      expect(action.call(foo: "123e4567e89b12d3a456426614174000")).to be_ok
+
+      expect(action.call(foo: nil)).not_to be_ok
+      expect(action.call(foo: "")).not_to be_ok
+      expect(action.call(foo: 1)).not_to be_ok
+      expect(action.call(foo: "abcabc")).not_to be_ok
+    end
+  end
 end

--- a/spec/axn/factory_spec.rb
+++ b/spec/axn/factory_spec.rb
@@ -134,6 +134,34 @@ RSpec.shared_examples "can build Axns from callables" do
       end
     end
   end
+
+  %i[error_from rescues].each do |setting|
+    context "setting #{setting}" do
+      let(:callable) do
+        -> { raise "error" }
+      end
+
+      context "as hash" do
+        let(:kwargs) do
+          { setting => { -> { true } => "overridden msg" } }
+        end
+
+        it "works correctly" do
+          expect(axn.call.error).to eq("overridden msg")
+        end
+      end
+
+      context "as array" do
+        let(:kwargs) do
+          { setting => [-> { true }, "overridden msg"] }
+        end
+
+        it "works correctly" do
+          expect(axn.call.error).to eq("overridden msg")
+        end
+      end
+    end
+  end
 end
 
 RSpec.describe Axn::Factory do

--- a/spec/oneoff_confirmations/interface_interdependency_spec.rb
+++ b/spec/oneoff_confirmations/interface_interdependency_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "One-off confirmation" do
 
           private
 
-          def self.valid_channels = %w[web email sms].freeze
+          def valid_channels = %w[web email sms].freeze
         end
       end
 


### PR DESCRIPTION
## 0.1.0-alpha.2.3
* `expects` / `exposes`: Add `type: :uuid` special case validation
* [BUGFIX] Allow `hoist_errors` to pass the result through on success (allow access to subactions' exposures)
* [`Axn::Factory`] Support error_from + rescues
* `Action::Result.error` spec helper -- creation should NOT trigger global exception handler
* [CHANGE] `expects` / `exposes`: The `default` key, if a callable, should be evaluated in the _instance_'s context