### PR TITLE
[0.1.0-alpha.2.5] Real-world usage support: Failure edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * Renamed to `Enqueueable::ViaSidekiq` (make it easier to support different background runners in the future)
   * Added ability to call `.enqueue_all_in_background` to run an Action's class-level `.enqueue_all` method (if defined) on a background worker
     (important if triggered via a clock process that is NOT intended to execute actual jobs)
+* Restructure internals (call/call! + run/run! + Action::Failure) to simplify upstream implementation since we always wrap any raised exceptions
 
 ## 0.1.0-alpha.2.4.1
 * [FEAT] Adds full suite of per-Axn callbacks: `on_exception`, `on_failure`, `on_error`, `on_success`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## UNRELEASED
+* N/A
+
+## 0.1.0-alpha.2.5
 * Support blank exposures for `Action::Result.ok`
 * Modify Action::Failure's initialize signature (to better match StandardError)
 * Reduce reserved fields to allow some `expects` (e.g. `message`) that would shadow internals if used as `exposes`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    axn (0.1.0.pre.alpha.2.4.1)
+    axn (0.1.0.pre.alpha.2.5)
       activemodel (> 7.0)
       activesupport (> 7.0)
       interactor (= 3.1.2)

--- a/docs/reference/instance.md
+++ b/docs/reference/instance.md
@@ -61,6 +61,12 @@ Accepts a `prefix` keyword argument -- when set, prefixes the `error` message fr
 
 NOTE: expects a single action call in the block -- if there are multiple calls, only the last one will be checked for `ok?` (although anything _raised_ in the block will still be handled).
 
+::: tip Versus `call!`
+* If you just want to make sure your action fails if the subaction fails: call subaction via `call!` (any failures will raise, which will fail the parent).
+  * Note this passes _child_ exception into _parent_ `messages :error` parsing.
+* If you want _the child's_ `result.error` to become the _parent's_ `result.error` on failure, use `hoist_errors` + `call`
+:::
+
 ### Example
 
 ```ruby

--- a/lib/action/core/configuration.rb
+++ b/lib/action/core/configuration.rb
@@ -16,7 +16,7 @@ module Action
         # TODO: only pass action: or context: if requested (and update documentation)
         @on_exception.call(e, action:, context:)
       else
-        log("[#{action.class.name.presence || "Anonymous Action"}] Exception swallowed: #{e.class.name} - #{e.message}")
+        log("[#{action.class.name.presence || "Anonymous Action"}] Exception raised: #{e.class.name} - #{e.message}")
       end
     end
 

--- a/lib/action/core/context_facade.rb
+++ b/lib/action/core/context_facade.rb
@@ -51,13 +51,8 @@ module Action
     def determine_error_message(only_default: false)
       return @context.error_from_user if @context.error_from_user.present?
 
-      # TODO: just one of these... :grimace:
-
-      # This is original -- errors if exception is nil when passing to stringified
-      exception = @context.exception || (only_default ? Action::Failure.new(context: @context) : nil)
-
-      # This was new attempt -- fixes stringification, but the ultimately-raised error message is the default (loses the custom message somewhere)
-      # exception = @context.exception || Action::Failure.new(context: @context)
+      # We need an exception for interceptors, and also in case the messages.error callable expects an argument
+      exception = @context.exception || Action::Failure.new(context: @context)
 
       msg = action._error_msg
 

--- a/lib/action/core/context_facade.rb
+++ b/lib/action/core/context_facade.rb
@@ -52,7 +52,7 @@ module Action
       return @context.error_from_user if @context.error_from_user.present?
 
       # We need an exception for interceptors, and also in case the messages.error callable expects an argument
-      exception = @context.exception || Action::Failure.new(context: @context)
+      exception = @context.exception || Action::Failure.new
 
       msg = action._error_msg
 

--- a/lib/action/core/context_facade.rb
+++ b/lib/action/core/context_facade.rb
@@ -51,7 +51,14 @@ module Action
     def determine_error_message(only_default: false)
       return @context.error_from_user if @context.error_from_user.present?
 
+      # TODO: just one of these... :grimace:
+
+      # This is original -- errors if exception is nil when passing to stringified
       exception = @context.exception || (only_default ? Action::Failure.new(context: @context) : nil)
+
+      # This was new attempt -- fixes stringification, but the ultimately-raised error message is the default (loses the custom message somewhere)
+      # exception = @context.exception || Action::Failure.new(context: @context)
+
       msg = action._error_msg
 
       unless only_default

--- a/lib/action/core/contract_validator.rb
+++ b/lib/action/core/contract_validator.rb
@@ -45,7 +45,7 @@ module Action
 
     class TypeValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
-        # TODO: the last one (:value) might be my fault from the make-it-a-hash fallback in #parse_field_configs
+        # NOTE: the last one (:value) might be my fault from the make-it-a-hash fallback in #parse_field_configs
         types = options[:in].presence || Array(options[:with]).presence || Array(options[:value]).presence
 
         return if value.blank? && !types.include?(:boolean) # Handled with a separate default presence validator

--- a/lib/action/core/exceptions.rb
+++ b/lib/action/core/exceptions.rb
@@ -5,18 +5,13 @@ module Action
   class Failure < StandardError
     DEFAULT_MESSAGE = "Execution was halted"
 
-    attr_reader :context
-
-    def initialize(message = nil, context: nil, **)
-      @context = context
+    def initialize(message = nil, **)
       @message = message
       super(**)
     end
 
     def message
-      @message.presence || @context&.error_from_user.presence || DEFAULT_MESSAGE
-    rescue StandardError
-      DEFAULT_MESSAGE
+      @message.presence || DEFAULT_MESSAGE
     end
 
     def inspect = "#<#{self.class.name} '#{message}'>"

--- a/lib/action/core/hoist_errors.rb
+++ b/lib/action/core/hoist_errors.rb
@@ -29,8 +29,10 @@ module Action
           MinimalFailedResult.new(error: nil, exception: e)
         end
 
-        # This ensures the last line of hoist_errors was an Action call (CAUTION: if there are multiple
-        # calls per block, only the last one will be checked!)
+        # This ensures the last line of hoist_errors was an Action call
+        #
+        # CAUTION: if there are multiple calls per block, only the last one will be checked!
+        #
         unless result.respond_to?(:ok?)
           raise ArgumentError,
                 "#hoist_errors is expected to wrap an Action call, but it returned a #{result.class.name} instead"

--- a/lib/action/core/hoist_errors.rb
+++ b/lib/action/core/hoist_errors.rb
@@ -48,6 +48,7 @@ module Action
         @context.exception = result.exception if result.exception.present?
         @context.error_prefix = prefix if prefix.present?
 
+        # TODO: do we maybe want to always use exception.message? :thinking:
         error = result.exception.is_a?(Action::Failure) ? result.exception.message : result.error
         fail! error
       end

--- a/lib/action/core/hoist_errors.rb
+++ b/lib/action/core/hoist_errors.rb
@@ -48,7 +48,6 @@ module Action
         @context.exception = result.exception if result.exception.present?
         @context.error_prefix = prefix if prefix.present?
 
-        # TODO: do we maybe want to always use exception.message? :thinking:
         error = result.exception.is_a?(Action::Failure) ? result.exception.message : result.error
         fail! error
       end

--- a/lib/action/core/swallow_exceptions.rb
+++ b/lib/action/core/swallow_exceptions.rb
@@ -62,7 +62,6 @@ module Action
         class << base
           def call!(context = {})
             result = call(context)
-
             return result if result.ok?
 
             # TODO: we might not need to pass context around, depending on how we clean up run/run!

--- a/lib/action/core/swallow_exceptions.rb
+++ b/lib/action/core/swallow_exceptions.rb
@@ -64,8 +64,7 @@ module Action
             result = call(context)
             return result if result.ok?
 
-            # TODO: we might not need to pass context around, depending on how we clean up run/run!
-            raise result.exception || Action::Failure.new(result.error, context: result.instance_variable_get("@context"))
+            raise result.exception || Action::Failure.new(result.error)
           end
         end
       end
@@ -146,8 +145,7 @@ module Action
         @context.instance_variable_set("@failure", true)
         @context.error_from_user = message if message.present?
 
-        # TODO: should we use context_for_logging here? But doublecheck the one place where we're checking object_id on it...
-        raise Action::Failure.new(message, context: @context)
+        raise Action::Failure, message
       end
 
       def try

--- a/lib/axn/factory.rb
+++ b/lib/axn/factory.rb
@@ -34,7 +34,6 @@ module Axn
         end
         raise ArgumentError, "[Axn::Factory] Cannot convert block to action: block expects a splat of keyword arguments" if args[:keyrest].present?
 
-        # TODO: is there any way to support default arguments? (if so, set allow_blank: true for those)
         if args[:key].present?
           raise ArgumentError,
                 "[Axn::Factory] Cannot convert block to action: block expects keyword arguments with defaults (ruby does not allow introspecting)"

--- a/lib/axn/version.rb
+++ b/lib/axn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Axn
-  VERSION = "0.1.0-alpha.2.4.1"
+  VERSION = "0.1.0-alpha.2.5"
 end

--- a/spec/action/core/exceptions_spec.rb
+++ b/spec/action/core/exceptions_spec.rb
@@ -1,27 +1,14 @@
 # frozen_string_literal: true
 
+# NOTE: remnant from previous more-complex behavior, leaving just to confirm basic here.
 RSpec.describe Action::Failure do
-  let(:context) { Interactor::Context.new(error_from_user:) }
-  let(:error_from_user) { nil }
-  let(:message) { nil }
-
   it "defaults to the default message" do
     expect(described_class.new.message).to eq(described_class::DEFAULT_MESSAGE)
   end
 
-  context "with a error_from_user on the context" do
-    let(:error_from_user) { "custom message" }
-
-    it "uses the error_from_user" do
-      expect(described_class.new(context:).message).to eq(error_from_user)
-    end
-
-    context "with a message" do
-      let(:message) { "custom message" }
-
-      it "uses the message" do
-        expect(described_class.new(message, context:).message).to eq(message)
-      end
+  context "with a custom message" do
+    it "uses the custom message" do
+      expect(described_class.new("foo").message).to eq("foo")
     end
   end
 end

--- a/spec/action/core/hoist_errors_nested_spec.rb
+++ b/spec/action/core/hoist_errors_nested_spec.rb
@@ -45,12 +45,10 @@ RSpec.describe Action do
           let(:bang) { true }
 
           it "inner call fails parent" do
-            pending "TODO: BUG -- if subaction raises `Action::Failure`, that gets passed through without being swallowed at the parent level"
-            expect { subject }.not_to raise_error
-            # is_expected.not_to be_ok
-            # expect(result.error).to eq("inner action failed")
-            # expect(result.exception).to be_a(Action::Failure)
-            # expect(result.exception.message).to eq("inner action failed")
+            is_expected.not_to be_ok
+            expect(result.error).to eq("inner action failed")
+            expect(result.exception).to be_a(Action::Failure)
+            expect(result.exception.message).to eq("inner action failed")
           end
         end
 

--- a/spec/action/core/hoist_errors_nested_spec.rb
+++ b/spec/action/core/hoist_errors_nested_spec.rb
@@ -23,11 +23,7 @@ RSpec.describe Action do
         expects :bang, allow_blank: true
         expects :hoist, allow_blank: true
 
-        # TODO: resolve the messages-from-fail! issue, then update specs to use this
-        # messages error: lambda { |e|
-        #   binding.pry
-        #   "outer action failed"
-        # }
+        messages error: ->(e) { "Outer action failed on a #{e.class.name}" }
 
         def call
           if hoist
@@ -52,7 +48,7 @@ RSpec.describe Action do
 
           it "inner call fails parent WITHOUT custom message" do
             is_expected.not_to be_ok
-            expect(result.error).to eq("Something went wrong")
+            expect(result.error).to eq("Outer action failed on a Action::Failure")
             expect(result.exception).to be_nil
           end
         end
@@ -100,7 +96,7 @@ RSpec.describe Action do
 
           it "inner call exception fails parent" do
             is_expected.not_to be_ok
-            expect(result.error).to eq("Something went wrong")
+            expect(result.error).to eq("Outer action failed on a RuntimeError")
             expect(result.exception).to be_a(RuntimeError)
             expect(result.exception.message).to eq("inner action failed")
           end
@@ -124,7 +120,7 @@ RSpec.describe Action do
           it "inner call fails parent (uses parent error message parsing, but NOT child's)" do
             is_expected.not_to be_ok
             expect(result.error).not_to eq("PREFIX sub bad") # we'd get this from child error message parsing, if called WITHOUT the bang
-            expect(result.error).to eq("PREFIX Something went wrong")
+            expect(result.error).to eq("PREFIX Outer action failed on a RuntimeError")
           end
         end
 

--- a/spec/action/core/messages_spec.rb
+++ b/spec/action/core/messages_spec.rb
@@ -146,6 +146,38 @@ RSpec.describe Action do
         it "supports class level default_error" do
           expect(action.default_error).to eq("Bad news: Action::Failure")
         end
+
+        context "when fail! is called with custom message" do
+          let(:action) do
+            build_action do
+              messages(error: ->(e) { "Bad news: #{e.message}" })
+
+              def call
+                fail! "Explicitly-set error message"
+              end
+            end
+          end
+
+          it "uses the custom message" do
+            is_expected.to eq("Explicitly-set error message")
+          end
+        end
+
+        context "when fail! is called without message" do
+          let(:action) do
+            build_action do
+              messages(error: ->(e) { "Bad news: #{e.message}" })
+
+              def call
+                fail!
+              end
+            end
+          end
+
+          it "uses the default message" do
+            is_expected.to eq("Bad news: Execution was halted")
+          end
+        end
       end
 
       context "when dynamic returns blank" do


### PR DESCRIPTION
Restructure internals (call/call! + run/run! + Action::Failure) to simplify upstream implementation (since we always wrap any raised exceptions, we don't need the same behavior vanilla Interactor does).

Addresses a number of edge cases around nested Axns that came up while pairing with other devs over the last week or two.