### PR TITLE
alpha-2.7.1: Implement symbol method handler support for callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.0-alpha.2.7.1
+* [FEAT] Implemented symbol method handler support for callbacks
+
 ## 0.1.0-alpha.2.7
 * [BREAKING] Replaced `messages` declaration with separate `success` and `error` calls
 * [BREAKING] Removed `rescues` method (use `error_from` for custom error messages; all exceptions now report to `on_exception` handlers)
@@ -7,7 +10,7 @@
   * [FEAT] Implemented conditional success message filtering as well
 * [FEAT] Added block support for `error` and `success`
 * [FEAT] `if:` now supports symbol predicates referencing instance methods (arity 0, 1, or keyword `exception:`). If the method accepts `exception:` it is passed as a keyword; else if it accepts one positional arg, it is passed positionally; otherwise it is called with no args. If the method is missing, the symbol falls back to constant lookup (e.g., `:ArgumentError`).
-* [FEAT] `success`/`error` and callbacks now accept symbol method names (e.g., `success :local_method`). Handlers can receive the exception via keyword (`exception:`) or single positional argument; otherwise they are called with no args.
+* [FEAT] `success`/`error` now accept symbol method names (e.g., `success :local_method`). Handlers can receive the exception via keyword (`exception:`) or single positional argument; otherwise they are called with no args.
 * [BREAKING] Updated callback methods (`on_success`, `on_error`, `on_failure`, `on_exception`) to use consistent `if:` interface (matching messages)
 * [FEAT] Added `unless:` support to both `success`/`error` messages and callbacks (`on_success`, `on_error`, `on_failure`, `on_exception`)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    axn (0.1.0.pre.alpha.2.7)
+    axn (0.1.0.pre.alpha.2.7.1)
       activemodel (> 7.0)
       activesupport (> 7.0)
 

--- a/docs/reference/action-result.md
+++ b/docs/reference/action-result.md
@@ -13,7 +13,7 @@ Every `call` invocation on an Action will return an `Action::Result` instance, w
 | `elapsed_time` | Execution time in milliseconds (Float)
 | any `expose`d values | guaranteed to be set if `ok?` (since they have outgoing presence validations by default; any missing would have failed the action)
 
-NOTE: `success` and `error` (and so implicitly `message`) can be configured per-action via [the `messages` declaration](/reference/class#messages).
+NOTE: `success` and `error` (and so implicitly `message`) can be configured per-action via [the `success` and `error` declarations](/reference/class#success-and-error).
 
 ### Clarification of exposed values
 

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -235,6 +235,16 @@ In addition to the [global exception handler](/reference/configuration#on-except
   * *Callbacks* (defined below) are executed _after_ the `call` -- exceptions or `fail!`s here will _not_ change `result.ok?`
 :::
 
+
+**Note:** Symbol method handlers for all callback types follow the same argument pattern as [message handlers](#conditional-messages):
+- If the method accepts `exception:` as a keyword, the exception is passed as a keyword
+- If the method accepts one positional argument, the exception is passed positionally
+- Otherwise, the method is called with no arguments
+
+::: warning
+You cannot use both `if:` and `unless:` for the same callback - this will raise an `ArgumentError`.
+:::
+
 ### `on_success`
 
 This is triggered after the Axn completes, if it was successful.  Difference from `after`: if the given block raises an error, this WILL be reported to the global exception handler, but will NOT change `ok?` to false.
@@ -280,16 +290,14 @@ def transient_error?
   name == "temporary"
 end
 
-::: warning
-You cannot use both `if:` and `unless:` for the same callback - this will raise an `ArgumentError`.
-:::
-
   on_exception(if: ->(e) { e.is_a?(ZeroDivisionError) }) do # [!code focus]
     # e.g. trigger a slack error
   end
 end
 ```
 
+
 If multiple `on_exception` handlers are provided, ALL that match the raised exception will be triggered in the order provided.
 
 The _global_ handler will be triggered _after_ all class-specific handlers.
+

--- a/docs/reference/instance.md
+++ b/docs/reference/instance.md
@@ -63,7 +63,7 @@ NOTE: expects a single action call in the block -- if there are multiple calls, 
 
 ::: tip Versus `call!`
 * If you just want to make sure your action fails if the subaction fails: call subaction via `call!` (any failures will raise, which will fail the parent).
-  * Note this passes _child_ exception into _parent_ `messages :error` parsing.
+  * Note this passes _child_ exception into _parent_ `error` message parsing.
 * If you want _the child's_ `result.error` to become the _parent's_ `result.error` on failure, use `hoist_errors` + `call`
 :::
 

--- a/docs/usage/writing.md
+++ b/docs/usage/writing.md
@@ -68,7 +68,7 @@ See [the reference doc](/reference/instance) for a few more handy helper methods
 
 The default `error` and `success` message strings ("Something went wrong" / "Action completed successfully", respectively) _are_ technically safe to show users, but you'll often want to set them to something more useful.
 
-There's a `messages` declaration for that -- you can set strings (most common) or a callable (note for the error case, if you give it a callable that expects a single argument, the exception that was raised will be passed in).
+There are `success` and `error` declarations for that -- you can set strings (most common) or a callable (note for the error case, if you give it a callable that expects a single argument, the exception that was raised will be passed in).
 
 For instance, configuring the action like this:
 
@@ -79,8 +79,8 @@ class Foo
   expects :name, type: String
   exposes :meaning_of_life
 
-  messages success: -> { "Revealed to #{name}: #{result.meaning_of_life}" }, # [!code focus:2]
-           error: ->(e) { "No secret of life for you: #{e.message}" }
+  success { "Revealed to #{name}: #{result.meaning_of_life}" } # [!code focus:2]
+  error { |e| "No secret of life for you: #{e.message}" }
 
   def call
     fail! "Douglas already knows the meaning" if name == "Doug"

--- a/lib/action/core/flow/callbacks.rb
+++ b/lib/action/core/flow/callbacks.rb
@@ -23,28 +23,29 @@ module Action
           end
 
           # ONLY raised exceptions (i.e. NOT fail!).
-          def on_exception(**, &block) = _add_callback(:exception, **, block:)
+          def on_exception(handler = nil, **, &block) = _add_callback(:exception, handler:, **, block:)
 
           # ONLY raised on fail! (i.e. NOT unhandled exceptions).
-          def on_failure(**, &block) = _add_callback(:failure, **, block:)
+          def on_failure(handler = nil, **, &block) = _add_callback(:failure, handler:, **, block:)
 
           # Handles both fail! and unhandled exceptions
-          def on_error(**, &block) = _add_callback(:error, **, block:)
+          def on_error(handler = nil, **, &block) = _add_callback(:error, handler:, **, block:)
 
           # Executes when the action completes successfully (after all after hooks complete successfully)
           # Runs in child-first order (child handlers before parent handlers)
-          def on_success(**, &block) = _add_callback(:success, **, block:)
+          def on_success(handler = nil, **, &block) = _add_callback(:success, handler:, **, block:)
 
           private
 
-          def _add_callback(event_type, block:, **kwargs)
+          def _add_callback(event_type, handler: nil, block: nil, **kwargs)
             raise ArgumentError, "on_#{event_type} cannot be called with both :if and :unless" if kwargs.key?(:if) && kwargs.key?(:unless)
 
             condition = kwargs.key?(:if) ? kwargs[:if] : kwargs[:unless]
-            raise ArgumentError, "on_#{event_type} must be called with a block" unless block
+            raise ArgumentError, "on_#{event_type} must be called with a block or symbol" unless block || handler
 
+            callback_handler = block || handler
             matcher = condition.nil? ? nil : Action::Core::Flow::Handlers::Matcher.new(condition, invert: kwargs.key?(:unless))
-            entry = Action::Core::Flow::Handlers::CallbackHandler.new(matcher:, handler: block)
+            entry = Action::Core::Flow::Handlers::CallbackHandler.new(matcher:, handler: callback_handler)
             self._callbacks_registry = _callbacks_registry.register(event_type:, entry:)
           end
         end

--- a/lib/axn/version.rb
+++ b/lib/axn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Axn
-  VERSION = "0.1.0-alpha.2.7"
+  VERSION = "0.1.0-alpha.2.7.1"
 end


### PR DESCRIPTION
## Summary
Added support for using symbol method names as callback handlers, allowing for cleaner and more maintainable callback implementations.

Also fixed some outdated documentation references.