### PR TITLE
Add Vernier Profiling Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* [FEAT] Added Vernier profiling support with `profile if:` conditional interface and `Axn.config.profiling` configuration
 * [FEAT] Extended model validation to support custom finder methods with `expects :user, model: { klass: User, finder: :find }` syntax
 * [BREAKING] Removed `#try` method
 * [BREAKING] Removed `Axn()` method sugar (use `Axn::Factory.build` directly)

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "pry-byebug", "3.11.0"
 gem "rails", "> 7.0" # For Rails Engine testing
 gem "rspec", "~> 3.2"
 gem "sqlite3", "~> 2.0" # For Rails Engine testing database
+gem "vernier", "~> 0.1" # For profiling support
 
 gem "rake", "~> 13.0"
 gem "rubocop", "~> 1.21"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,7 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     useragent (0.16.11)
+    vernier (0.8.0)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -253,6 +254,7 @@ DEPENDENCIES
   rspec (~> 3.2)
   rubocop (~> 1.21)
   sqlite3 (~> 2.0)
+  vernier (~> 0.1)
 
 BUNDLED WITH
    2.5.6

--- a/axn.gemspec
+++ b/axn.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/teamshares/axn"
   spec.license = "MIT"
 
-  # NOTE: uses endless methods from 3, literal value omission from 3.1, Data.define from 3.2
-  spec.required_ruby_version = ">= 3.2.0"
+  # NOTE: uses endless methods from 3, literal value omission from 3.1, Data.define from 3.2, Vernier profiling from 3.2.1
+  spec.required_ruby_version = ">= 3.2.1"
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
   # spec.metadata["rubygems_mfa_required"] = "true"

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -55,10 +55,11 @@ export default defineConfig({
         ]
       },
       {
-        text: 'Additional Notes',
+        text: 'Advanced',
         items: [
-          { text: 'ROUGH NOTES', link: '/advanced/rough' },
+          { text: 'Profiling', link: '/advanced/profiling' },
           { text: 'Conventions', link: '/advanced/conventions' },
+          { text: 'ROUGH NOTES', link: '/advanced/rough' },
         ]
       },
     ],

--- a/docs/advanced/profiling.md
+++ b/docs/advanced/profiling.md
@@ -1,0 +1,343 @@
+# Profiling
+
+Axn supports performance profiling using [Vernier](https://github.com/Shopify/vernier), a Ruby sampling profiler that provides detailed insights into your action's performance characteristics.
+
+## Overview
+
+Profiling helps you identify performance bottlenecks in your actions by capturing detailed execution traces. Vernier is particularly useful for:
+
+- Identifying slow methods and code paths
+- Understanding memory allocation patterns
+- Analyzing call stacks and execution flow
+- Optimizing performance-critical actions
+
+## Setup
+
+### 1. Install Vernier
+
+Add the Vernier gem to your Gemfile:
+
+```ruby
+# Gemfile
+gem 'vernier', '~> 0.1'
+```
+
+Then run:
+
+```bash
+bundle install
+```
+
+**Note:** Vernier is not included as a dependency of Axn, so you must explicitly add it to your Gemfile if you want to use profiling features.
+
+### 2. Enable Profiling
+
+Configure Axn to enable profiling globally:
+
+```ruby
+# config/initializers/axn.rb
+Axn.configure do |c|
+  c.profiling_enabled = true  # Master switch - must be true for ANY profiling
+  c.profiling_sample_rate = 0.1  # Profile 10% of executions
+  c.profiling_output_dir = "tmp/profiles"
+end
+```
+
+**Important**: This only enables the global profiling switch. You must also declare `profile` on each action you want to profile (see Basic Usage below).
+
+## Basic Usage
+
+Profiling uses a **two-tier opt-in system**:
+
+1. **Global Switch**: `Axn.config.profiling_enabled = true` (master kill switch)
+2. **Per-Action Declaration**: Each action must call `profile` to be eligible
+
+**Important**: You can only call `profile` **once per action** - subsequent calls will override the previous one. This prevents accidental profiling of all actions and ensures you only profile what you intend to analyze.
+
+### Simple Profiling
+
+Enable profiling on any action:
+
+```ruby
+class UserCreation
+  include Axn
+
+  # Always profile this action
+  profile
+
+  expects :user_params
+
+  def call
+    user = User.create!(user_params)
+    send_welcome_email(user)
+  end
+
+  private
+
+  def send_welcome_email(user)
+    UserMailer.welcome(user).deliver_now
+  end
+end
+```
+
+### Conditional Profiling
+
+Profile only under specific conditions:
+
+```ruby
+class DataProcessing
+  include Axn
+
+  # Profile only when processing large datasets (only one profile call per action)
+  profile if: -> { record_count > 1000 }
+
+  expects :records, :record_count
+
+  def call
+    records.each { |record| process_record(record) }
+  end
+end
+```
+
+**Alternative using a method:**
+
+```ruby
+class DataProcessing
+  include Axn
+
+  # Profile using a method (only one profile call per action)
+  profile if: :should_profile?
+
+  expects :records, :record_count, :debug_mode, type: :boolean, default: false
+
+  def should_profile?
+    record_count > 1000 || debug_mode
+  end
+
+  def call
+    records.each { |record| process_record(record) }
+  end
+end
+```
+
+
+## Advanced Usage
+
+### Sampling Rate Control
+
+Adjust the sampling rate based on your needs:
+
+```ruby
+Axn.configure do |c|
+  c.profiling_enabled = true
+
+  # High sampling rate for development (more detailed data)
+  c.profiling_sample_rate = 0.5 if Rails.env.development?
+
+  # Low sampling rate for production (minimal overhead)
+  c.profiling_sample_rate = 0.01 if Rails.env.production?
+end
+```
+
+### Custom Output Directory
+
+Organize profiles by environment or feature:
+
+```ruby
+Axn.configure do |c|
+  c.profiling_enabled = true
+  c.profiling_output_dir = Rails.root.join("tmp", "profiles", Rails.env)
+end
+```
+
+### Multiple Conditions
+
+Combine multiple profiling conditions:
+
+```ruby
+class ComplexAction
+  include Axn
+
+  # Profile when debug mode is enabled OR when processing admin users
+  profile if: -> { debug_mode || user.admin? }
+
+  expects :user, :debug_mode, type: :boolean, default: false
+
+  def call
+    # Complex logic
+  end
+end
+```
+
+## Viewing and Analyzing Profiles
+
+### 1. Generate Profile Data
+
+Run your action with profiling enabled:
+
+```ruby
+# This will generate a profile file if conditions are met
+result = UserCreation.call(user_params: { name: "John", email: "john@example.com" })
+```
+
+### 2. Locate Profile Files
+
+Profile files are saved as JSON in your configured output directory:
+
+```bash
+# Default location
+ls tmp/profiles/
+
+# Example output
+axn_UserCreation_1703123456.json
+axn_DataProcessing_1703123457.json
+```
+
+### 3. View in Firefox Profiler
+
+1. Open [profiler.firefox.com](https://profiler.firefox.com/)
+2. Click "Load a profile from file"
+3. Select your generated JSON file
+4. Analyze the performance data
+
+### 4. Understanding the Profile
+
+The Firefox Profiler provides several views:
+
+- **Call Tree**: Shows the complete call stack with timing
+- **Flame Graph**: Visual representation of call stacks
+- **Stack Chart**: Timeline view of function calls
+- **Markers**: Custom markers and events
+
+## Best Practices
+
+### 1. Use Conditional Profiling
+
+Avoid profiling all actions in production:
+
+```ruby
+# Good: Conditional profiling
+profile if: -> { Rails.env.development? || debug_mode }
+
+# Avoid: Always profiling in production
+profile  # This can impact performance
+```
+
+### 2. Appropriate Sampling Rates
+
+Choose sampling rates based on your environment:
+
+```ruby
+Axn.configure do |c|
+  c.profiling_enabled = true
+
+  case Rails.env
+  when 'development'
+    c.profiling_sample_rate = 0.5  # High detail for debugging
+  when 'staging'
+    c.profiling_sample_rate = 0.1  # Moderate sampling
+  when 'production'
+    c.profiling_sample_rate = 0.01 # Minimal overhead
+  end
+end
+```
+
+### 3. Profile Specific Scenarios
+
+Focus on performance-critical paths:
+
+```ruby
+class OrderProcessing
+  include Axn
+
+  # Profile only expensive operations
+  profile if: -> { order.total > 1000 }
+
+  expects :order
+
+  def call
+    process_payment
+    send_confirmation
+    update_inventory
+  end
+end
+```
+
+### 4. Clean Up Old Profiles
+
+Implement profile cleanup to avoid disk space issues:
+
+```ruby
+# Add to a rake task or cron job
+namespace :profiles do
+  desc "Clean up old profile files"
+  task cleanup: :environment do
+    profile_dir = Rails.root.join("tmp", "profiles")
+    Dir.glob(File.join(profile_dir, "*.json")).each do |file|
+      File.delete(file) if File.mtime(file) < 7.days.ago
+    end
+  end
+end
+```
+
+## Troubleshooting
+
+### Vernier Not Available
+
+If you see this error:
+
+```
+LoadError: Vernier gem is not loaded. Add `gem 'vernier', '~> 0.1'` to your Gemfile to enable profiling.
+```
+
+Make sure to:
+1. Add `vernier` to your Gemfile
+2. Run `bundle install`
+3. Restart your application
+
+### No Profile Files Generated
+
+If profile files aren't being generated:
+
+1. Check that `Axn.config.profiling_enabled = true`
+2. Verify your action has `profile` enabled
+3. Ensure profiling conditions are met
+4. Check the output directory exists and is writable
+
+### Performance Impact
+
+Profiling adds overhead to your application:
+
+- **Sampling overhead**: ~1-5% depending on sample rate
+- **File I/O**: Profile files are written to disk
+- **Memory usage**: Slight increase due to sampling
+
+Use appropriate sampling rates and conditional profiling to minimize impact.
+
+## Integration with Other Tools
+
+### Datadog Integration
+
+Combine profiling with Datadog tracing:
+
+```ruby
+Axn.configure do |c|
+  # Profiling
+  c.profiling_enabled = true
+  c.profiling_sample_rate = 0.1
+
+  # Datadog tracing
+  c.wrap_with_trace = proc do |resource, &action|
+    Datadog::Tracing.trace("Action", resource:) do
+      action.call
+    end
+  end
+end
+```
+
+## Resources
+
+- [Vernier GitHub Repository](https://github.com/Shopify/vernier)
+- [Firefox Profiler](https://profiler.firefox.com/)
+- [Ruby Performance Optimization Guide](https://ruby-doc.org/core-3.2.1/doc/performance_rdoc.html)
+- [Axn Configuration Reference](/reference/configuration)

--- a/examples/profiling_usage.rb
+++ b/examples/profiling_usage.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Example: Using axn profiling with Vernier
+#
+# To use profiling, you need to:
+# 1. Add 'vernier' to your Gemfile: gem 'vernier', '~> 0.1'
+# 2. Enable profiling in your configuration
+# 3. Enable profiling on specific actions
+
+require_relative "../lib/axn"
+
+# Configure profiling
+Axn.configure do |c|
+  c.profiling_enabled = true
+  c.profiling_sample_rate = 0.1 # Profile 10% of executions
+  c.profiling_output_dir = "tmp/profiles"
+end
+
+# Example 1: Simple profiling
+class SimpleAction
+  include Axn
+
+  # Enable profiling for this action
+  profile
+
+  expects :name
+
+  def call
+    # Simulate some work
+    sleep(0.01)
+    "Hello, #{name}!"
+  end
+end
+
+# Example 2: Conditional profiling
+class ConditionalAction
+  include Axn
+
+  # Only profile when debug_mode is true
+  profile if: -> { debug_mode }
+
+  expects :name, :debug_mode
+
+  def call
+    # Simulate some work
+    sleep(0.01)
+    "Hello, #{name}!"
+  end
+end
+
+# Example 3: Symbol-based condition
+class SymbolConditionAction
+  include Axn
+
+  # Use a method to determine when to profile
+  profile if: :should_profile?
+
+  expects :name, :user_id
+
+  def call
+    # Simulate some work
+    sleep(0.01)
+    "Hello, #{name}!"
+  end
+
+  private
+
+  def should_profile?
+    # Only profile for specific users
+    user_id == 123
+  end
+end
+
+# Example 4: Callable condition
+class CallableConditionAction
+  include Axn
+
+  # Use a callable object to determine when to profile
+  profile if: -> { name.include?("Action") }
+
+  expects :name
+
+  def call
+    # Simulate some work
+    sleep(0.01)
+    "Hello, #{name}!"
+  end
+end
+
+puts "Profiling examples loaded!"
+puts "To use profiling:"
+puts "1. Add 'vernier' to your Gemfile"
+puts "2. Enable profiling: Axn.config.profiling_enabled = true"
+puts "3. Enable profiling on actions: MyAction.profile"
+puts "4. Run your actions normally - they'll be profiled when conditions are met"
+puts "5. View profiles in Firefox Profiler: https://profiler.firefox.com/"

--- a/lib/axn/configuration.rb
+++ b/lib/axn/configuration.rb
@@ -7,11 +7,15 @@ module Axn
 
   class Configuration
     attr_accessor :wrap_with_trace, :emit_metrics
-    attr_writer :logger, :env, :on_exception, :additional_includes, :log_level, :rails
+    attr_writer :logger, :env, :on_exception, :additional_includes, :log_level, :rails, :profiling_enabled, :profiling_sample_rate, :profiling_output_dir
 
     def log_level = @log_level ||= :info
 
     def additional_includes = @additional_includes ||= []
+
+    def profiling_enabled = @profiling_enabled ||= false
+    def profiling_sample_rate = @profiling_sample_rate ||= 0.1
+    def profiling_output_dir = @profiling_output_dir ||= _default_profiling_output_dir
 
     def _default_async_adapter = @default_async_adapter ||= false
     def _default_async_config = @default_async_config ||= {}
@@ -59,6 +63,16 @@ module Axn
     def env
       @env ||= ENV["RACK_ENV"].presence || ENV["RAILS_ENV"].presence || "development"
       ActiveSupport::StringInquirer.new(@env)
+    end
+
+    private
+
+    def _default_profiling_output_dir
+      if defined?(Rails) && Rails.respond_to?(:root)
+        Rails.root.join("tmp", "profiles")
+      else
+        Pathname.new("tmp/profiles")
+      end
     end
   end
 

--- a/lib/axn/core.rb
+++ b/lib/axn/core.rb
@@ -12,6 +12,7 @@ require "axn/core/automatic_logging"
 require "axn/core/use_strategy"
 require "axn/core/timing"
 require "axn/core/tracing"
+require "axn/core/profiling"
 require "axn/core/nesting_tracking"
 
 # CONSIDER: make class names match file paths?
@@ -35,6 +36,7 @@ module Axn
         include Core::AutomaticLogging
         include Core::Tracing
         include Core::Timing
+        include Core::Profiling
 
         include Core::Flow
 
@@ -72,13 +74,15 @@ module Axn
     # Main entry point for action execution
     def _run
       _tracking_nesting(self) do
-        _with_tracing do
-          _with_logging do
-            _with_timing do
-              _with_exception_handling do # Exceptions stop here; outer wrappers access result status (and must not introduce another exception layer)
-                _with_contract do # Library internals -- any failures (e.g. contract violations) *should* fail the Action::Result
-                  _with_hooks do # User hooks -- any failures here *should* fail the Action::Result
-                    call
+        _with_profiling do
+          _with_tracing do
+            _with_logging do
+              _with_timing do
+                _with_exception_handling do # Exceptions stop here; outer wrappers access result status (and must not introduce another exception layer)
+                  _with_contract do # Library internals -- any failures (e.g. contract violations) *should* fail the Action::Result
+                    _with_hooks do # User hooks -- any failures here *should* fail the Action::Result
+                      call
+                    end
                   end
                 end
               end

--- a/lib/axn/core/profiling.rb
+++ b/lib/axn/core/profiling.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "axn/core/flow/handlers/invoker"
+
+module Axn
+  module Core
+    module Profiling
+      def self.included(base)
+        base.class_eval do
+          class_attribute :_profiling_enabled, default: false
+          class_attribute :_profiling_condition, default: nil
+
+          extend ClassMethods
+        end
+      end
+
+      module ClassMethods
+        # Enable profiling for this action class
+        #
+        # @param if [Proc, Symbol, #call, nil] Optional condition to determine when to profile
+        # @return [void]
+        def profile(if: nil)
+          self._profiling_enabled = true
+          self._profiling_condition = binding.local_variable_get(:if)
+        end
+      end
+
+      private
+
+      def _with_profiling(&)
+        # Fastest path: global profiling disabled
+        return yield unless Axn.config.profiling_enabled
+
+        # Check if this specific action should be profiled
+        return yield unless _should_profile?
+
+        _profile_with_vernier(&)
+      end
+
+      def _profile_with_vernier(&)
+        _ensure_vernier_available!
+
+        class_name = self.class.name.presence || "AnonymousAction"
+        profile_name = "axn_#{class_name}_#{Time.now.to_i}"
+
+        # Ensure output directory exists (only once per instance)
+        _ensure_output_directory_exists
+
+        # Build output file path
+        output_file = File.join(Axn.config.profiling_output_dir, "#{profile_name}.json")
+
+        # Configure Vernier with our settings
+        collector_options = {
+          out: output_file,
+          allocation_sample_rate: (Axn.config.profiling_sample_rate * 1000).to_i,
+        }
+
+        Vernier.profile(**collector_options, &)
+      end
+
+      def _ensure_output_directory_exists
+        return if @_profiling_directory_created
+
+        output_dir = Axn.config.profiling_output_dir
+        FileUtils.mkdir_p(output_dir)
+        @_profiling_directory_created = true
+      end
+
+      def _should_profile?
+        # Fast path: check if action has profiling enabled
+        return false unless self.class._profiling_enabled
+
+        # Fast path: no condition means always profile
+        return true unless self.class._profiling_condition
+
+        # Slow path: evaluate condition (only when needed)
+        Axn::Core::Flow::Handlers::Invoker.call(
+          action: self,
+          handler: self.class._profiling_condition,
+          operation: "determining if profiling should run",
+        )
+      end
+
+      def _ensure_vernier_available!
+        return if defined?(Vernier) && Vernier.is_a?(Module)
+
+        begin
+          require "vernier"
+        rescue LoadError
+          raise LoadError, <<~ERROR
+            Vernier profiler is not available. To use profiling, add 'vernier' to your Gemfile:
+
+              gem 'vernier', '~> 0.1'
+
+            Then run: bundle install
+          ERROR
+        end
+      end
+    end
+  end
+end

--- a/spec/axn/core/global_on_exception_spec.rb
+++ b/spec/axn/core/global_on_exception_spec.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+RSpec.describe "Global on_exception handler" do
+  let(:original_handler) { Axn.config.instance_variable_get(:@on_exception) }
+  before do
+    # Clear any existing global handler
+    Axn.config.instance_variable_set(:@on_exception, nil)
+  end
+
+  after do
+    # Restore original handler
+    Axn.config.instance_variable_set(:@on_exception, original_handler)
+  end
+
+  describe "basic functionality" do
+    let(:action) do
+      build_axn do
+        expects :name, type: String
+        expects :age, type: Integer, numericality: { greater_than: 0 }
+        exposes :processed_name
+
+        def call
+          raise "Something went wrong!" if name == "error"
+
+          expose :processed_name, "Hello, #{name}!"
+        end
+      end
+    end
+
+    context "when no global handler is set" do
+      before do
+        Axn.config.instance_variable_set(:@on_exception, nil)
+      end
+
+      it "logs the exception but doesn't call a custom handler" do
+        expect_any_instance_of(action).to receive(:log).with(
+          "#{"#" * 10} Handled exception (RuntimeError): Something went wrong! #{"#" * 10}",
+        )
+        expect(action.call(name: "error", age: 25)).not_to be_ok
+      end
+    end
+
+    context "when global handler is set" do
+      it "calls the global handler with exception, action, and context" do
+        expect(Axn.config).to receive(:on_exception).with(
+          an_instance_of(RuntimeError),
+          action: an_instance_of(action),
+          context: { name: "error", age: 25 },
+        ).and_call_original
+
+        result = action.call(name: "error", age: 25)
+        expect(result).not_to be_ok
+      end
+
+      it "doesn't call handler when action succeeds" do
+        expect(Axn.config).not_to receive(:on_exception)
+        result = action.call(name: "success", age: 25)
+        expect(result).to be_ok
+      end
+    end
+  end
+
+  describe "handler parameter variations" do
+    let(:action) do
+      build_axn do
+        expects :trigger_error, type: :boolean, default: false
+
+        def call
+          raise "Test error" if trigger_error
+        end
+      end
+    end
+
+    context "handler accepts only exception" do
+      it "calls handler with only exception" do
+        expect(Axn.config).to receive(:on_exception).with(
+          an_instance_of(RuntimeError),
+          action: an_instance_of(action),
+          context: { trigger_error: true },
+        ).and_call_original
+
+        action.call(trigger_error: true)
+      end
+    end
+
+    context "handler accepts exception and action" do
+      it "calls handler with exception and action" do
+        expect(Axn.config).to receive(:on_exception).with(
+          an_instance_of(RuntimeError),
+          action: an_instance_of(action),
+          context: { trigger_error: true },
+        ).and_call_original
+
+        action.call(trigger_error: true)
+      end
+    end
+
+    context "handler accepts exception and context" do
+      it "calls handler with exception and context" do
+        expect(Axn.config).to receive(:on_exception).with(
+          an_instance_of(RuntimeError),
+          action: an_instance_of(action),
+          context: { trigger_error: true },
+        ).and_call_original
+
+        action.call(trigger_error: true)
+      end
+    end
+
+    context "handler accepts all parameters" do
+      it "calls handler with all parameters" do
+        expect(Axn.config).to receive(:on_exception).with(
+          an_instance_of(RuntimeError),
+          action: an_instance_of(action),
+          context: { trigger_error: true },
+        ).and_call_original
+
+        action.call(trigger_error: true)
+      end
+    end
+  end
+
+  describe "sensitive data filtering" do
+    let(:action) do
+      build_axn do
+        expects :username, type: String
+        expects :password, type: String, sensitive: true
+        expects :email, type: String, sensitive: true
+        expects :age, type: Integer
+        exposes :user_id
+
+        def call
+          raise "Database error" if username == "fail"
+
+          expose :user_id, 123
+        end
+      end
+    end
+
+    it "filters sensitive data from context" do
+      expect(Axn.config).to receive(:on_exception).with(
+        an_instance_of(RuntimeError),
+        action: an_instance_of(action),
+        context: {
+          username: "fail",
+          password: "[FILTERED]",
+          email: "[FILTERED]",
+          age: 30,
+        },
+      ).and_call_original
+
+      action.call(username: "fail", password: "secret123", email: "user@example.com", age: 30)
+    end
+  end
+
+  describe "error handling in global handler" do
+    let(:action) do
+      build_axn do
+        expects :trigger_error, type: :boolean, default: false
+
+        def call
+          raise "Something went wrong" if trigger_error
+        end
+      end
+    end
+
+    it "logs handler errors without affecting original exception" do
+      Axn.config.on_exception = proc do |e|
+        raise "Handler error: #{e.message}"
+      end
+
+      expect(Axn::Internal::Logging).to receive(:piping_error).with(
+        "executing on_exception hooks",
+        hash_including(action: an_instance_of(action), exception: an_object_satisfying { |e|
+          e.is_a?(RuntimeError) && e.message == "Handler error: Something went wrong"
+        }),
+      )
+
+      result = action.call(trigger_error: true)
+      expect(result).not_to be_ok
+      expect(result.error).to eq("Something went wrong")
+    end
+  end
+
+  describe "multiple exception types" do
+    let(:action) do
+      build_axn do
+        expects :error_type, type: String, default: "RuntimeError"
+
+        def call
+          case error_type
+          when "RuntimeError"
+            raise "Runtime error"
+          when "ArgumentError"
+            raise ArgumentError, "Invalid argument"
+          when "NoMethodError"
+            raise NoMethodError, "Method not found"
+          end
+        end
+      end
+    end
+
+    it "handles different exception types" do
+      expect(Axn.config).to receive(:on_exception).with(
+        an_instance_of(RuntimeError),
+        action: an_instance_of(action),
+        context: { error_type: "RuntimeError" },
+      ).and_call_original
+
+      action.call(error_type: "RuntimeError")
+    end
+  end
+
+  describe "production vs development logging" do
+    let(:action) do
+      build_axn do
+        def call
+          raise "Test error"
+        end
+      end
+    end
+
+    context "in development environment" do
+      before do
+        allow(Axn.config).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+      end
+
+      it "logs with decorative formatting" do
+        expect(Axn.config).to receive(:on_exception).and_call_original
+        expect_any_instance_of(action).to receive(:log).with(
+          "#{"#" * 10} Handled exception (RuntimeError): Test error #{"#" * 10}",
+        )
+        action.call
+      end
+    end
+
+    context "in production environment" do
+      before do
+        allow(Axn.config).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+      end
+
+      it "logs without decorative formatting" do
+        expect(Axn.config).to receive(:on_exception).and_call_original
+        expect_any_instance_of(action).to receive(:log).with(
+          "Handled exception (RuntimeError): Test error",
+        )
+        action.call
+      end
+    end
+  end
+
+  describe "integration with action-specific on_exception" do
+    let(:action) do
+      build_axn do
+        expects :trigger_error, type: :boolean, default: false
+
+        def call
+          raise "Test error" if trigger_error
+        end
+      end
+    end
+
+    it "calls global handler" do
+      expect(Axn.config).to receive(:on_exception).with(
+        an_instance_of(RuntimeError),
+        action: an_instance_of(action),
+        context: { trigger_error: true },
+      ).and_call_original
+
+      expect_any_instance_of(action).to receive(:log).with(
+        "#{"#" * 10} Handled exception (RuntimeError): Test error #{"#" * 10}",
+      )
+
+      result = action.call(trigger_error: true)
+      expect(result).not_to be_ok
+    end
+  end
+end

--- a/spec/axn/core/profiling_spec.rb
+++ b/spec/axn/core/profiling_spec.rb
@@ -183,8 +183,8 @@ RSpec.describe Axn::Core::Profiling do
 
     context "when profiling should run" do
       before do
-        Axn.config.profiling_enabled = true  # Enable global profiling
-        action_class.profile  # Enable profiling on the action class
+        Axn.config.profiling_enabled = true # Enable global profiling
+        action_class.profile # Enable profiling on the action class
         allow(action).to receive(:_should_profile?).and_return(true)
         stub_const("Vernier", Module.new)
         allow(Vernier).to receive(:profile).and_yield

--- a/spec/axn/core/profiling_spec.rb
+++ b/spec/axn/core/profiling_spec.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+RSpec.describe Axn::Core::Profiling do
+  let(:action_class) do
+    build_axn do
+      expects :name
+
+      def call
+        "Hello, #{name}!"
+      end
+    end
+  end
+
+  before do
+    # Reset configuration
+    Axn.config.profiling_enabled = false
+    action_class._profiling_enabled = false
+    action_class._profiling_condition = nil
+  end
+
+  describe ".profile" do
+    it "enables profiling for the action class" do
+      action_class.profile
+
+      expect(action_class._profiling_enabled).to be true
+      expect(action_class._profiling_condition).to be nil
+    end
+
+    it "enables profiling with a condition" do
+      condition = -> { debug_mode }
+      action_class.profile(if: condition)
+
+      expect(action_class._profiling_enabled).to be true
+      expect(action_class._profiling_condition).to eq(condition)
+    end
+
+    it "enables profiling with a symbol condition" do
+      action_class.profile(if: :should_profile?)
+
+      expect(action_class._profiling_enabled).to be true
+      expect(action_class._profiling_condition).to eq(:should_profile?)
+    end
+  end
+
+  describe "#_should_profile?" do
+    let(:action) { action_class.new(name: "World") }
+
+    context "when profiling is disabled globally" do
+      before { Axn.config.profiling_enabled = false }
+
+      it "returns true (global check moved to _with_profiling)" do
+        action_class._profiling_enabled = true
+        # _should_profile? no longer checks global setting, so it returns true
+        # The global check is now in _with_profiling
+        expect(action.send(:_should_profile?)).to be true
+      end
+    end
+
+    context "when profiling is disabled for the action" do
+      before { Axn.config.profiling_enabled = true }
+
+      it "returns false" do
+        action_class._profiling_enabled = false
+        expect(action.send(:_should_profile?)).to be false
+      end
+    end
+
+    context "when profiling is enabled without condition" do
+      before do
+        Axn.config.profiling_enabled = true
+        action_class._profiling_enabled = true
+      end
+
+      it "returns true" do
+        expect(action.send(:_should_profile?)).to be true
+      end
+    end
+
+    context "when profiling is enabled with proc condition" do
+      let(:action_class) do
+        build_axn do
+          expects :name, :debug_mode
+
+          def call
+            "Hello, #{name}!"
+          end
+        end
+      end
+
+      before do
+        Axn.config.profiling_enabled = true
+        action_class._profiling_enabled = true
+      end
+
+      it "returns true when condition evaluates to true" do
+        action_class._profiling_condition = -> { debug_mode }
+        action = action_class.new(name: "World", debug_mode: true)
+
+        expect(action.send(:_should_profile?)).to be true
+      end
+
+      it "returns false when condition evaluates to false" do
+        action_class._profiling_condition = -> { debug_mode }
+        action = action_class.new(name: "World", debug_mode: false)
+
+        expect(action.send(:_should_profile?)).to be false
+      end
+    end
+
+    context "when profiling is enabled with symbol condition" do
+      before do
+        Axn.config.profiling_enabled = true
+        action_class._profiling_enabled = true
+      end
+
+      it "calls the method and returns its result" do
+        action_class._profiling_condition = :should_profile?
+
+        expect(action).to receive(:should_profile?).and_return(true)
+        expect(action.send(:_should_profile?)).to be true
+      end
+    end
+
+    context "when profiling is enabled with callable condition" do
+      before do
+        Axn.config.profiling_enabled = true
+        action_class._profiling_enabled = true
+      end
+
+      it "calls the callable and returns its result" do
+        callable = -> { name == "World" }
+        action_class._profiling_condition = callable
+
+        expect(action.send(:_should_profile?)).to be true
+      end
+    end
+  end
+
+  describe "#_ensure_vernier_available!" do
+    let(:action) { action_class.new(name: "World") }
+
+    context "when Vernier is available" do
+      before do
+        stub_const("Vernier", Module.new)
+      end
+
+      it "does not raise an error" do
+        expect { action.send(:_ensure_vernier_available!) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#_with_profiling" do
+    let(:action) { action_class.new(name: "World") }
+
+    context "when profiling should not run" do
+      before do
+        allow(action).to receive(:_should_profile?).and_return(false)
+      end
+
+      it "yields without profiling" do
+        expect(action).not_to receive(:_ensure_vernier_available!)
+
+        result = action.send(:_with_profiling) { "test" }
+        expect(result).to eq("test")
+      end
+    end
+
+    context "when global profiling is disabled" do
+      before do
+        Axn.config.profiling_enabled = false
+        action_class._profiling_enabled = true
+      end
+
+      it "yields without profiling" do
+        expect(action).not_to receive(:_ensure_vernier_available!)
+        expect(action).not_to receive(:_should_profile?)
+
+        result = action.send(:_with_profiling) { "test" }
+        expect(result).to eq("test")
+      end
+    end
+
+    context "when profiling should run" do
+      before do
+        Axn.config.profiling_enabled = true  # Enable global profiling
+        action_class.profile  # Enable profiling on the action class
+        allow(action).to receive(:_should_profile?).and_return(true)
+        stub_const("Vernier", Module.new)
+        allow(Vernier).to receive(:profile).and_yield
+      end
+
+      it "ensures Vernier is available" do
+        expect(action).to receive(:_ensure_vernier_available!)
+
+        action.send(:_with_profiling) { "test" }
+      end
+
+      it "calls Vernier.profile with a profile name and options" do
+        expect(Vernier).to receive(:profile).with(
+          hash_including(
+            out: match(/axn_AnonymousAction_\d+\.json$/),
+            allocation_sample_rate: 100,
+          ),
+        ).and_yield
+
+        action.send(:_with_profiling) { "test" }
+      end
+
+      it "yields the block to Vernier.profile" do
+        yielded_value = nil
+        allow(Vernier).to receive(:profile) do |&block|
+          yielded_value = block.call
+        end
+
+        result = action.send(:_with_profiling) { "test" }
+        expect(yielded_value).to eq("test")
+        expect(result).to eq("test")
+      end
+    end
+  end
+
+  describe "integration with action execution" do
+    let(:action) { action_class.new(name: "World") }
+
+    before do
+      Axn.config.profiling_enabled = true
+      action_class.profile
+      stub_const("Vernier", Module.new)
+      allow(Vernier).to receive(:profile).and_yield
+    end
+
+    it "profiles the complete action execution" do
+      expect(Vernier).to receive(:profile).with(
+        hash_including(
+          out: match(/axn_AnonymousAction_\d+\.json$/),
+          allocation_sample_rate: 100,
+        ),
+      ).and_yield
+
+      action_class.call(name: "World")
+    end
+
+    it "includes the action class name in the profile name" do
+      expect(Vernier).to receive(:profile).with(
+        hash_including(
+          out: match(/axn_AnonymousAction_\d+\.json$/),
+          allocation_sample_rate: 100,
+        ),
+      ).and_yield
+
+      action_class.call(name: "World")
+    end
+  end
+
+  describe "configuration" do
+    it "has default profiling configuration" do
+      expect(Axn.config.profiling_enabled).to be false
+      expect(Axn.config.profiling_sample_rate).to eq(0.1)
+      expect(Axn.config.profiling_output_dir).to be_a(Pathname)
+    end
+
+    it "allows setting profiling configuration" do
+      Axn.configure do |c|
+        c.profiling_enabled = true
+        c.profiling_sample_rate = 0.5
+        c.profiling_output_dir = Pathname.new("custom/profiles")
+      end
+
+      expect(Axn.config.profiling_enabled).to be true
+      expect(Axn.config.profiling_sample_rate).to eq(0.5)
+      expect(Axn.config.profiling_output_dir).to eq(Pathname.new("custom/profiles"))
+    end
+  end
+end


### PR DESCRIPTION
This PR adds comprehensive performance profiling support to Axn using [Vernier](https://github.com/Shopify/vernier), a Ruby sampling profiler.

## Key Features

- **Two-tier opt-in system**: Global switch (`profiling_enabled`) + per-action declaration (`profile`)
- **Conditional profiling**: Profile only when specific conditions are met using `profile if: -> { condition }`
- **Configurable sampling**: Adjust sample rate and output directory via `Axn.config`
- **Firefox Profiler integration**: Generated JSON profiles can be viewed in Firefox Profiler
- **Zero-dependency**: Vernier is not included as a dependency - must be explicitly added to Gemfile

## Usage

```ruby
# Global configuration
Axn.configure do |c|
  c.profiling_enabled = true
  c.profiling_sample_rate = 0.1
  c.profiling_output_dir = "tmp/profiles"
end

# Per-action profiling
class MyAction
  include Axn
  
  expects :debug_mode, type: :boolean, default: false

  profile if: -> { debug_mode }
  
  def call
    # Action logic
  end
end
```

## Breaking Changes

- **Ruby version requirement**: Updated from `>= 3.2.0` to `>= 3.2.1` due to Vernier dependency